### PR TITLE
reloadTask - crate and update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
         "binarydelete",
         "binarydownload",
         "binarysyncruleevaluation",
+        "certificatedistribution",
         "compositeevent",
         "compositeeventoperational",
         "compositeeventruleoperational",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.14] - 2022-02-07
+
+### Fixed
+
+- `reloadTask.create` and `reloadTask.update` accepts and `appFilter` argument [#47](https://github.com/Informatiqal/qlik-repo-api/issues/47)
+
 ## [0.1.14] - 2022-01-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qlik-repo-api",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Interact with Qlik Sense Repository API (QSEoW)",
   "author": {
     "email": "info@informatiqal.com",

--- a/src/ReloadTaskBase.ts
+++ b/src/ReloadTaskBase.ts
@@ -18,6 +18,7 @@ import { IClassSchemaTrigger, SchemaTrigger } from "./SchemaTrigger";
 import { CompositeTrigger, IClassCompositeTrigger } from "./CompositeTrigger";
 import { TDaysOfMonth, TDaysOfWeek, TRepeatOptions } from "./types/ranges";
 import { schemaRepeat } from "./util/schemaTrigger";
+import { getAppForReloadTask } from "./util/ReloadTaskUtil";
 
 export interface IClassReloadTask {
   remove(): Promise<IHttpStatus>;
@@ -160,6 +161,15 @@ export abstract class ReloadTaskBase implements IClassReloadTask {
     if (arg.taskSessionTimeout)
       this.details.taskSessionTimeout = arg.taskSessionTimeout;
     if (arg.maxRetries) this.details.maxRetries = arg.maxRetries;
+
+    if (arg.appId || arg.appFilter) {
+      const app = await getAppForReloadTask(
+        arg.appId,
+        arg.appFilter,
+        this.repoClient
+      );
+      this.details.app = app.details;
+    }
 
     let updateCommon = new UpdateCommonProperties(
       this.repoClient,

--- a/src/Task.interface.ts
+++ b/src/Task.interface.ts
@@ -11,7 +11,8 @@ import {
 
 export interface ITaskCreate {
   name: string;
-  appId: string;
+  appId?: string;
+  appFilter?: string;
   tags?: string[];
   customProperties?: string[];
 }
@@ -25,6 +26,8 @@ export interface ITaskReloadUpdate {
   tags?: string[];
   customProperties?: string[];
   owner?: string;
+  appId?: string;
+  appFilter?: string;
 }
 
 export type TTaskTriggerCompositeState = "success" | "fail";

--- a/src/util/ReloadTaskUtil.ts
+++ b/src/util/ReloadTaskUtil.ts
@@ -1,0 +1,44 @@
+import { QlikRepositoryClient } from "qlik-rest-api";
+import { App } from "../App";
+import { Apps } from "../Apps";
+
+export async function getAppForReloadTask(
+  appId: string,
+  appFilter: string,
+  repoClient: QlikRepositoryClient
+): Promise<App> {
+  let returnAppId: string = "";
+  let returnAppsFilter: App;
+
+  // without appId and appFilter - throw error
+  if (!appId && !appFilter)
+    throw new Error(
+      `task.create: "appId" or "appFilter" parameter is required`
+    );
+
+  const apps = new Apps(repoClient, undefined);
+  const appsFilter = await apps.getFilter({
+    filter: appFilter || `id eq ${appId}`,
+  });
+
+  // if both exists, then appId is with priority
+  if (appId && appFilter) returnAppId = appId;
+  // if only appId exists
+  if (appId && !appFilter) returnAppId = appId;
+  // if only appFilter exists, then fetch the app(s) using the Apps class
+  // if more than one app is returned, then throw an Error
+  // if no apps are returned, then throw an Error
+  // if only one app is returned, then get the appId from the first element
+  if (!appId && appFilter) {
+    if (appsFilter.length > 1)
+      throw new Error(`task.create: "appFilter" returned more than one app`);
+    if (appsFilter.length == 0)
+      throw new Error(`task.create: "appFilter" returned 0 apps`);
+    if (appsFilter.length == 1) {
+      returnAppId = appsFilter[0].details.id;
+      returnAppsFilter = appsFilter[0];
+    }
+  }
+
+  return returnAppsFilter || appsFilter[0];
+}


### PR DESCRIPTION
reloadTask `crate` and `update` methods now accept AND `appFilter` parameter. If this parameter is provided the app id (and meta) is extracted based on the filter provided. **One and only one** app should be returned by the filter query. If not, error will be thrown