### PR TITLE
v.0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ temp.md
 .VSCodeCounter
 src/main.doc.ts
 .npmrc
+test/Test.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2022-02-07
+
+### Fixed
+
+- all methods expose only the required properties. Removed exposure of `repoClient` or `genericClient` or `id`. Whenever available these properties should be kept internal to the class [#49](https://github.com/Informatiqal/qlik-repo-api/issues/49)
+
 ## [0.1.14] - 2022-02-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "qlik-repo-api",
-  "version": "0.1.10",
+  "version": "0.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.10",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
         "name2mime": "^1.0.1",
-        "qlik-rest-api": "^1.3.2"
+        "qlik-rest-api": "^1.3.4"
       },
       "devDependencies": {
         "@types/chai": "^4.2.19",
@@ -23,52 +23,65 @@
         "rollup-plugin-delete": "^2.0.0",
         "rollup-plugin-typescript2": "^0.30.0",
         "ts-node": "^10.0.0",
+        "tslib": "^2.1.0",
         "typedoc": "^0.22.10",
         "typescript": "^4.3.2"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+    "node_modules/@ampproject/remapping": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.4.tgz",
+      "integrity": "sha512-zU3pj3pf//YhaoozRTYKaL20KopXrzuZFc/8Ylc49AuV8grYKH23TTq9JJoR70F8zQbil58KjSchZTWeX+jrIQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@jridgewell/trace-mapping": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
-      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
+      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
-      "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.0.tgz",
+      "integrity": "sha512-x/5Ea+RO5MvF9ize5DeVICJoVrNv0Mi2RnIABrZEKYvPEpldXwauPkgvYA17cKa6WpU3LoYvYbuEMFtSNFsarA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
-        "@babel/helper-compilation-targets": "^7.14.5",
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helpers": "^7.14.6",
-        "@babel/parser": "^7.14.6",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5",
+        "@ampproject/remapping": "^2.0.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.0",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helpers": "^7.17.0",
+        "@babel/parser": "^7.17.0",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.0",
+        "@babel/types": "^7.17.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
+        "semver": "^6.3.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -79,12 +92,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
+      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.17.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -93,14 +106,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.15.0",
-        "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.16.6",
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-validator-option": "^7.16.7",
+        "browserslist": "^4.17.5",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -110,177 +123,150 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.15.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
+      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
-      "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.0.tgz",
+      "integrity": "sha512-Xe/9NFxjPwELUvW2dsukcMZIp6XwPSbI4ojFBJuX5ramHuVE22SVcZIwqzdWo5uCgeTXW8qV97lMvSOjq+1+nQ==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.0",
+        "@babel/types": "^7.17.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -360,9 +346,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
-      "integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
+      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -372,32 +358,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
+      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.0",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.0",
+        "@babel/types": "^7.17.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -406,16 +393,37 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -441,15 +449,6 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
@@ -526,6 +525,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
+      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.10.tgz",
+      "integrity": "sha512-Ht8wIW5v165atIX1p+JvKR5ONzUyF4Ac8DZIQ5kZs9zrb6M8SJNXpx1zn04rn65VjBMygRoMXcyYwNK0fT7bEg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.2.tgz",
+      "integrity": "sha512-9KzzH4kMjA2XmBRHfqG2/Vtl7s92l6uNDd0wW7frDE+EUvQFGqNXhWp0UGJjSkt3v2AYjzOZn1QO9XaTNJIt1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -562,9 +586,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
-      "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
+      "integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
       "dev": true,
       "dependencies": {
         "estree-walker": "^2.0.1",
@@ -593,21 +617,21 @@
       "dev": true
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
-      "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
     "node_modules/@types/chai": {
-      "version": "4.2.19",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.19.tgz",
-      "integrity": "sha512-jRJgpRBuY+7izT7/WNXP/LsMO9YonsstuL+xuvycDyESpoDoIAsMd7suwpB4h9oEWB+ZlPTqJJ8EHomzNhwTPQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
       "dev": true
     },
     "node_modules/@types/glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
       "dev": true,
       "dependencies": {
         "@types/minimatch": "*",
@@ -621,15 +645,15 @@
       "dev": true
     },
     "node_modules/@types/mocha": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
-      "integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+      "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.0.tgz",
-      "integrity": "sha512-+aHJvoCsVhO2ZCuT4o5JtcPrCPyDE3+1nvbDprYes+pPkEsbjH7AGUCNtjMOXS0fqH14t+B7yLzaqSz92FPWyw==",
+      "version": "15.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
+      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
       "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -637,6 +661,27 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
@@ -797,16 +842,16 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
+      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001219",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.723",
+        "caniuse-lite": "^1.0.30001286",
+        "electron-to-chromium": "^1.4.17",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.71"
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -818,12 +863,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
     },
     "node_modules/caching-transform": {
       "version": "4.0.0",
@@ -841,21 +880,18 @@
       }
     },
     "node_modules/camelcase": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001240",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001240.tgz",
-      "integrity": "sha512-nb8mDzfMdxBDN7ZKx8chWafAdBp5DAAlpWvNyUGe5tcDWd838zpzDN3Rah9cjCqhfOKkrvx40G2SDtP0qiWX/w==",
+      "version": "1.0.30001309",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
+      "integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -863,15 +899,16 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       },
@@ -880,9 +917,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -958,9 +995,9 @@
       }
     },
     "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -976,26 +1013,26 @@
       }
     },
     "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -1019,12 +1056,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/colorette": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "dev": true
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1045,12 +1076,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "node_modules/convert-source-map/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1096,15 +1121,12 @@
       "dev": true
     },
     "node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true,
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/deep-eql": {
@@ -1181,9 +1203,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.759",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.759.tgz",
-      "integrity": "sha512-nM76xH0t2FBH5iMEZDVc3S/qbdKjGH7TThezxC8k1Q7w7WHvIAyJh8lAe2UamGfdRqBTjHfPDn82LJ0ksCiB9g==",
+      "version": "1.4.65",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.65.tgz",
+      "integrity": "sha512-0/d8Skk8sW3FxXP0Dd6MnBlrwx7Qo9cqQec3BlIAlvKnrmS3pHsIbaroEi+nd0kZkGpQ6apMEre7xndzjlEnLw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1239,9 +1261,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1251,13 +1273,13 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1276,9 +1298,9 @@
       }
     },
     "node_modules/find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "dependencies": {
         "commondir": "^1.0.1",
@@ -1506,9 +1528,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
       "dev": true
     },
     "node_modules/growl": {
@@ -1573,9 +1595,9 @@
       "dev": true
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -1628,9 +1650,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -1658,9 +1680,9 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -1706,12 +1728,15 @@
       }
     },
     "node_modules/is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-typedarray": {
@@ -1736,9 +1761,9 @@
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -1816,9 +1841,9 @@
       }
     },
     "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -1826,7 +1851,7 @@
         "source-map": "^0.6.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
@@ -1839,9 +1864,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
+      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -1944,13 +1969,13 @@
         "node": ">=10"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+    "node_modules/loupe": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.3.tgz",
+      "integrity": "sha512-krIV4Cf1BIGIx2t1e6tucThhrBemUnIUjMtD2vN4mrMxnxpBvrcosBSpooqunBqP/hOEEV1w/Cr1YskGtqw5Jg==",
       "dev": true,
       "dependencies": {
-        "yallist": "^3.0.2"
+        "get-func-name": "^2.0.0"
       }
     },
     "node_modules/lunr": {
@@ -1981,12 +2006,12 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "dev": true,
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 12"
@@ -2112,9 +2137,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.73",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -2168,21 +2193,12 @@
       }
     },
     "node_modules/nyc/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/nyc/node_modules/cliui": {
@@ -2194,15 +2210,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/nyc/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/nyc/node_modules/find-up": {
@@ -2267,26 +2274,26 @@
       }
     },
     "node_modules/nyc/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -2354,15 +2361,6 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/onigasm": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^5.1.1"
       }
     },
     "node_modules/p-limit": {
@@ -2482,10 +2480,16 @@
         "node": "*"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -2571,9 +2575,9 @@
       }
     },
     "node_modules/qlik-rest-api": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/qlik-rest-api/-/qlik-rest-api-1.3.2.tgz",
-      "integrity": "sha512-BeVi+fXYVZzhFflfeWBK4UHAinE9TYeG23koGWONamchqs3tnk5+Lumx1VESOsl1bn6fmTtAYLUj0Gar4R8g8g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/qlik-rest-api/-/qlik-rest-api-1.3.4.tgz",
+      "integrity": "sha512-8CmgBv6n83DoaokxHsB5pYnnD81AvaMpyBd26rXBPZlQyoBB6vU+9wnzKvA+gUCUzM0YGceW0MNWdEXgqtR9CQ==",
       "dependencies": {
         "axios": "^0.24.0"
       },
@@ -2697,9 +2701,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.56.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
-      "integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
+      "version": "2.67.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.1.tgz",
+      "integrity": "sha512-1Sbcs4OuW+aD+hhqpIRl+RqooIpF6uQcfzU/QSI7vGkwADY6cM4iLsBGRM2CGLXDTDN5y/yShohFmnKegSPWzg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2740,6 +2744,12 @@
         "typescript": ">=2.4.0"
       }
     },
+    "node_modules/rollup-plugin-typescript2/node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2764,24 +2774,10 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -2829,20 +2825,20 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.12.tgz",
-      "integrity": "sha512-VXcROdldv0/Qu0w2XvzU4IrvTeBNs/Kj/FCmtcEXGz7Tic/veQzliJj6tEiAgoKianhQstpYmbPDStHU5Opqcw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
+      "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
       "dev": true,
       "dependencies": {
         "jsonc-parser": "^3.0.0",
-        "onigasm": "^2.2.5",
+        "vscode-oniguruma": "^1.6.1",
         "vscode-textmate": "5.2.0"
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "node_modules/slash": {
@@ -2858,25 +2854,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3002,20 +2979,22 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
-      "integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "dev": true,
       "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.1",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       },
       "bin": {
@@ -3025,12 +3004,9 @@
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=12.0.0"
-      },
       "peerDependencies": {
-        "@swc/core": ">=1.2.45",
-        "@swc/wasm": ">=1.2.45",
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
         "@types/node": "*",
         "typescript": ">=2.7"
       },
@@ -3053,9 +3029,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
     "node_modules/type-detect": {
@@ -3086,16 +3062,16 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
-      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "version": "0.22.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
+      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
       "dev": true,
       "dependencies": {
         "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^3.0.8",
+        "marked": "^4.0.10",
         "minimatch": "^3.0.4",
-        "shiki": "^0.9.12"
+        "shiki": "^0.10.0"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -3128,9 +3104,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3158,6 +3134,12 @@
       "bin": {
         "uuid": "bin/uuid"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
     },
     "node_modules/vscode-textmate": {
       "version": "5.2.0",
@@ -3219,9 +3201,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3237,26 +3219,26 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -3288,12 +3270,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -3337,10 +3313,34 @@
         "node": ">=10"
       }
     },
+    "node_modules/yargs-unparser/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3356,26 +3356,26 @@
       }
     },
     "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -3404,199 +3404,187 @@
     }
   },
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+    "@ampproject/remapping": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.4.tgz",
+      "integrity": "sha512-zU3pj3pf//YhaoozRTYKaL20KopXrzuZFc/8Ylc49AuV8grYKH23TTq9JJoR70F8zQbil58KjSchZTWeX+jrIQ==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.14.5"
+        "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.16.7"
       }
     },
     "@babel/compat-data": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
-      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
+      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
-      "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.0.tgz",
+      "integrity": "sha512-x/5Ea+RO5MvF9ize5DeVICJoVrNv0Mi2RnIABrZEKYvPEpldXwauPkgvYA17cKa6WpU3LoYvYbuEMFtSNFsarA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
-        "@babel/helper-compilation-targets": "^7.14.5",
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helpers": "^7.14.6",
-        "@babel/parser": "^7.14.6",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5",
+        "@ampproject/remapping": "^2.0.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.0",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helpers": "^7.17.0",
+        "@babel/parser": "^7.17.0",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.0",
+        "@babel/types": "^7.17.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
+        "semver": "^6.3.0"
       }
     },
     "@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
+      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.17.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.15.0",
-        "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.16.6",
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-validator-option": "^7.16.7",
+        "browserslist": "^4.17.5",
         "semver": "^6.3.0"
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.15.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
+      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.14.5"
-      }
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
-      "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.0.tgz",
+      "integrity": "sha512-Xe/9NFxjPwELUvW2dsukcMZIp6XwPSbI4ojFBJuX5ramHuVE22SVcZIwqzdWo5uCgeTXW8qV97lMvSOjq+1+nQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.0",
+        "@babel/types": "^7.17.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -3660,47 +3648,63 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
-      "integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
+      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
+      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.0",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.0",
+        "@babel/types": "^7.17.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -3724,12 +3728,6 @@
           "requires": {
             "sprintf-js": "~1.0.2"
           }
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
         },
         "find-up": {
           "version": "4.1.0",
@@ -3786,6 +3784,28 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
+      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.10.tgz",
+      "integrity": "sha512-Ht8wIW5v165atIX1p+JvKR5ONzUyF4Ac8DZIQ5kZs9zrb6M8SJNXpx1zn04rn65VjBMygRoMXcyYwNK0fT7bEg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.2.tgz",
+      "integrity": "sha512-9KzzH4kMjA2XmBRHfqG2/Vtl7s92l6uNDd0wW7frDE+EUvQFGqNXhWp0UGJjSkt3v2AYjzOZn1QO9XaTNJIt1Q==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3813,9 +3833,9 @@
       }
     },
     "@rollup/pluginutils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
-      "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
+      "integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
       "dev": true,
       "requires": {
         "estree-walker": "^2.0.1",
@@ -3841,21 +3861,21 @@
       "dev": true
     },
     "@tsconfig/node16": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
-      "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
     "@types/chai": {
-      "version": "4.2.19",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.19.tgz",
-      "integrity": "sha512-jRJgpRBuY+7izT7/WNXP/LsMO9YonsstuL+xuvycDyESpoDoIAsMd7suwpB4h9oEWB+ZlPTqJJ8EHomzNhwTPQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
       "dev": true
     },
     "@types/glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
@@ -3869,21 +3889,33 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
-      "integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+      "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.0.tgz",
-      "integrity": "sha512-+aHJvoCsVhO2ZCuT4o5JtcPrCPyDE3+1nvbDprYes+pPkEsbjH7AGUCNtjMOXS0fqH14t+B7yLzaqSz92FPWyw==",
+      "version": "15.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
+      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
       "dev": true
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
     "aggregate-error": {
@@ -4012,23 +4044,17 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
+      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001219",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.723",
+        "caniuse-lite": "^1.0.30001286",
+        "electron-to-chromium": "^1.4.17",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.71"
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
       }
-    },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
     },
     "caching-transform": {
       "version": "4.0.0",
@@ -4043,35 +4069,36 @@
       }
     },
     "camelcase": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001240",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001240.tgz",
-      "integrity": "sha512-nb8mDzfMdxBDN7ZKx8chWafAdBp5DAAlpWvNyUGe5tcDWd838zpzDN3Rah9cjCqhfOKkrvx40G2SDtP0qiWX/w==",
+      "version": "1.0.30001309",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
+      "integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA==",
       "dev": true
     },
     "chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
     },
     "chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -4129,9 +4156,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -4141,23 +4168,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -4175,12 +4202,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "colorette": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "commondir": {
@@ -4202,14 +4223,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
       }
     },
     "create-require": {
@@ -4247,9 +4260,9 @@
       }
     },
     "decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "deep-eql": {
@@ -4308,9 +4321,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.759",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.759.tgz",
-      "integrity": "sha512-nM76xH0t2FBH5iMEZDVc3S/qbdKjGH7TThezxC8k1Q7w7WHvIAyJh8lAe2UamGfdRqBTjHfPDn82LJ0ksCiB9g==",
+      "version": "1.4.65",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.65.tgz",
+      "integrity": "sha512-0/d8Skk8sW3FxXP0Dd6MnBlrwx7Qo9cqQec3BlIAlvKnrmS3pHsIbaroEi+nd0kZkGpQ6apMEre7xndzjlEnLw==",
       "dev": true
     },
     "emoji-regex": {
@@ -4350,9 +4363,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4363,9 +4376,9 @@
       }
     },
     "fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -4381,9 +4394,9 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -4528,9 +4541,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
       "dev": true
     },
     "growl": {
@@ -4577,9 +4590,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "imurmurhash": {
@@ -4620,9 +4633,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -4641,9 +4654,9 @@
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -4674,9 +4687,9 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
     "is-typedarray": {
@@ -4698,9 +4711,9 @@
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -4762,9 +4775,9 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -4781,9 +4794,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
+      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -4859,13 +4872,13 @@
         "chalk": "^4.0.0"
       }
     },
-    "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+    "loupe": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.3.tgz",
+      "integrity": "sha512-krIV4Cf1BIGIx2t1e6tucThhrBemUnIUjMtD2vN4mrMxnxpBvrcosBSpooqunBqP/hOEEV1w/Cr1YskGtqw5Jg==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "get-func-name": "^2.0.0"
       }
     },
     "lunr": {
@@ -4890,9 +4903,9 @@
       "dev": true
     },
     "marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "dev": true
     },
     "merge2": {
@@ -4986,9 +4999,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.73",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
       "dev": true
     },
     "normalize-path": {
@@ -5033,15 +5046,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "cliui": {
@@ -5054,12 +5061,6 @@
             "strip-ansi": "^6.0.0",
             "wrap-ansi": "^6.2.0"
           }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
         },
         "find-up": {
           "version": "4.1.0",
@@ -5105,23 +5106,23 @@
           }
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "wrap-ansi": {
@@ -5179,15 +5180,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "onigasm": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^5.1.1"
       }
     },
     "p-limit": {
@@ -5271,10 +5263,16 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pkg-dir": {
@@ -5335,9 +5333,9 @@
       }
     },
     "qlik-rest-api": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/qlik-rest-api/-/qlik-rest-api-1.3.2.tgz",
-      "integrity": "sha512-BeVi+fXYVZzhFflfeWBK4UHAinE9TYeG23koGWONamchqs3tnk5+Lumx1VESOsl1bn6fmTtAYLUj0Gar4R8g8g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/qlik-rest-api/-/qlik-rest-api-1.3.4.tgz",
+      "integrity": "sha512-8CmgBv6n83DoaokxHsB5pYnnD81AvaMpyBd26rXBPZlQyoBB6vU+9wnzKvA+gUCUzM0YGceW0MNWdEXgqtR9CQ==",
       "requires": {
         "axios": "^0.24.0"
       }
@@ -5419,9 +5417,9 @@
       }
     },
     "rollup": {
-      "version": "2.56.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
-      "integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
+      "version": "2.67.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.1.tgz",
+      "integrity": "sha512-1Sbcs4OuW+aD+hhqpIRl+RqooIpF6uQcfzU/QSI7vGkwADY6cM4iLsBGRM2CGLXDTDN5y/yShohFmnKegSPWzg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -5447,6 +5445,14 @@
         "fs-extra": "8.1.0",
         "resolve": "1.20.0",
         "tslib": "2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
       }
     },
     "run-parallel": {
@@ -5459,9 +5465,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "semver": {
@@ -5501,20 +5507,20 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.12.tgz",
-      "integrity": "sha512-VXcROdldv0/Qu0w2XvzU4IrvTeBNs/Kj/FCmtcEXGz7Tic/veQzliJj6tEiAgoKianhQstpYmbPDStHU5Opqcw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
+      "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^3.0.0",
-        "onigasm": "^2.2.5",
+        "vscode-oniguruma": "^1.6.1",
         "vscode-textmate": "5.2.0"
       }
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "slash": {
@@ -5528,24 +5534,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
-    },
-    "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
     },
     "spawn-wrap": {
       "version": "2.0.0",
@@ -5634,20 +5622,22 @@
       }
     },
     "ts-node": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
-      "integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.1",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -5660,9 +5650,9 @@
       }
     },
     "tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
     "type-detect": {
@@ -5687,16 +5677,16 @@
       }
     },
     "typedoc": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
-      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "version": "0.22.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
+      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
       "dev": true,
       "requires": {
         "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^3.0.8",
+        "marked": "^4.0.10",
         "minimatch": "^3.0.4",
-        "shiki": "^0.9.12"
+        "shiki": "^0.10.0"
       },
       "dependencies": {
         "glob": {
@@ -5716,9 +5706,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "universalify": {
@@ -5731,6 +5721,12 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
       "dev": true
     },
     "vscode-textmate": {
@@ -5781,9 +5777,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -5793,23 +5789,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -5838,12 +5834,6 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
     },
-    "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
-    },
     "yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -5860,9 +5850,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -5872,23 +5862,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -5909,6 +5899,20 @@
         "decamelize": "^4.0.0",
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        }
       }
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qlik-repo-api",
-  "version": "0.1.15",
+  "version": "0.2.0",
   "description": "Interact with Qlik Sense Repository API (QSEoW)",
   "author": {
     "email": "info@informatiqal.com",
@@ -59,11 +59,12 @@
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-typescript2": "^0.30.0",
     "ts-node": "^10.0.0",
+    "tslib": "^2.1.0",
     "typedoc": "^0.22.10",
     "typescript": "^4.3.2"
   },
   "dependencies": {
     "name2mime": "^1.0.1",
-    "qlik-rest-api": "^1.3.2"
+    "qlik-rest-api": "^1.3.4"
   }
 }

--- a/src/About.ts
+++ b/src/About.ts
@@ -21,33 +21,37 @@ export interface IClassAbout {
 }
 
 export class About implements IClassAbout {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get() {
-    return await this.repoClient.Get(`about`).then((res) => res.data as IAbout);
+    return await this.#repoClient
+      .Get(`about`)
+      .then((res) => res.data as IAbout);
   }
 
   public async enums() {
-    return await this.repoClient.Get(`about/api/enums`).then((res) => res.data);
+    return await this.#repoClient
+      .Get(`about/api/enums`)
+      .then((res) => res.data);
   }
 
   public async openApi() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`about/openapi`)
       .then((res) => res.data as string[]);
   }
 
   public async apiRelations() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`about/api/relations`)
       .then((res) => res.data as string[]);
   }
 
   public async apiDescription() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`about/api/description`)
       .then((res) => res.data as string[]);
   }
@@ -55,7 +59,7 @@ export class About implements IClassAbout {
   public async apiDefaults(arg: { path: string }) {
     if (!arg.path)
       throw new Error(`about.apiDefaults: "path" parameter is required`);
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`about/api/default/${arg.path}`)
       .then((res) => res.data);
   }

--- a/src/AppObject.ts
+++ b/src/AppObject.ts
@@ -24,8 +24,8 @@ export interface IClassAppObject {
 }
 
 export class AppObject implements IClassAppObject {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: IAppObject;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -34,21 +34,21 @@ export class AppObject implements IClassAppObject {
   ) {
     if (!id) throw new Error(`appObjects.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`app/object/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`app/object/${this.#id}`)
         .then((res) => res.data as IAppObject);
     }
   }
 
   public async publish() {
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`app/object/${this.details.id}/publish`, {})
       .then((res) => {
         this.details = res.data;
@@ -57,7 +57,7 @@ export class AppObject implements IClassAppObject {
   }
 
   public async unPublish() {
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`app/object/${this.details.id}/unpublish`, {})
       .then((res) => {
         this.details = res.data;
@@ -66,7 +66,7 @@ export class AppObject implements IClassAppObject {
   }
 
   public async remove() {
-    return await this.repoClient
+    return await this.#repoClient
       .Delete(`app/object/${this.details.id}`)
       .then((res) => res.status);
   }
@@ -75,14 +75,14 @@ export class AppObject implements IClassAppObject {
     if (arg.approved) this.details.approved = arg.approved;
 
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`app/object/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IAppObject);
   }

--- a/src/AppObjects.ts
+++ b/src/AppObjects.ts
@@ -44,25 +44,25 @@ export interface IClassAppObjects {
   select(arg?: { filter: string }): Promise<ISelection>;
 }
 export class AppObjects implements IClassAppObjects {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
-    const appObject: AppObject = new AppObject(this.repoClient, arg.id, null);
+    const appObject: AppObject = new AppObject(this.#repoClient, arg.id, null);
     await appObject.init();
 
     return appObject;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`app/object/full`)
       .then((res) => res.data as IAppObject[])
       .then((data) => {
         return data.map((t) => {
-          return new AppObject(this.repoClient, t.id, t);
+          return new AppObject(this.#repoClient, t.id, t);
         });
       });
   }
@@ -71,12 +71,12 @@ export class AppObjects implements IClassAppObjects {
     if (!arg.filter)
       throw new Error(`appObject.filter: "filter" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`app/object/full?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as IAppObject[])
       .then((data) => {
         return data.map((t) => {
-          return new AppObject(this.repoClient, t.id, t);
+          return new AppObject(this.#repoClient, t.id, t);
         });
       });
   }
@@ -108,7 +108,7 @@ export class AppObjects implements IClassAppObjects {
     const urlBuild = new URLBuild(`selection/app/object`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/Apps.ts
+++ b/src/Apps.ts
@@ -59,31 +59,36 @@ export interface IClassApps {
 }
 
 export class Apps implements IClassApps {
-  private repoClient: QlikRepositoryClient;
-  private genericClient: QlikGenericRestClient;
+  #repoClient: QlikRepositoryClient;
+  #genericClient: QlikGenericRestClient;
   constructor(
     private mainRepoClient: QlikRepositoryClient,
     private mainGenericClient: QlikGenericRestClient
   ) {
-    this.repoClient = mainRepoClient;
-    this.genericClient = mainGenericClient;
+    this.#repoClient = mainRepoClient;
+    this.#genericClient = mainGenericClient;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id) throw new Error(`apps.get: "id" parameter is required`);
-    const app: App = new App(this.repoClient, arg.id, null, this.genericClient);
+    const app: App = new App(
+      this.#repoClient,
+      arg.id,
+      null,
+      this.#genericClient
+    );
     await app.init();
 
     return app;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`app/full`)
       .then((res) => res.data as IApp[])
       .then((data) => {
         return data.map(
-          (t) => new App(this.repoClient, t.id, t, this.genericClient)
+          (t) => new App(this.#repoClient, t.id, t, this.#genericClient)
         );
       });
   }
@@ -96,12 +101,12 @@ export class Apps implements IClassApps {
     urlBuild.addParam("filter", arg.filter);
     urlBuild.addParam("orderby", arg.orderBy);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(urlBuild.getUrl())
       .then((res) => res.data as IApp[])
       .then((data) => {
         return data.map(
-          (t) => new App(this.repoClient, t.id, t, this.genericClient)
+          (t) => new App(this.#repoClient, t.id, t, this.#genericClient)
         );
       });
   }
@@ -120,15 +125,15 @@ export class Apps implements IClassApps {
     urlBuild.addParam("keepdata", arg.keepData);
     urlBuild.addParam("excludeconnections", arg.excludeDataConnections);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), arg.file, "application/vnd.qlik.sense.app")
       .then(
         (res) =>
           new App(
-            this.repoClient,
+            this.#repoClient,
             (res.data as IApp).id,
             res.data,
-            this.genericClient
+            this.#genericClient
           )
       );
   }
@@ -153,15 +158,15 @@ export class Apps implements IClassApps {
     urlBuild.addParam("keepdata", arg.keepData);
     urlBuild.addParam("targetappid", arg.targetAppId);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), arg.file, "application/vnd.qlik.sense.app")
       .then(
         (res) =>
           new App(
-            this.repoClient,
+            this.#repoClient,
             (res.data as IApp).id,
             null,
-            this.genericClient
+            this.#genericClient
           )
       );
   }
@@ -182,7 +187,7 @@ export class Apps implements IClassApps {
     const urlBuild = new URLBuild(`selection/app`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/Certificate.ts
+++ b/src/Certificate.ts
@@ -16,13 +16,13 @@ export interface IClassCertificate {
 }
 
 export class Certificate implements IClassCertificate {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async distributionPathGet() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`certificatedistribution/exportcertificatespath`)
       .then((res) => {
         return res.data as string;
@@ -45,7 +45,7 @@ export class Certificate implements IClassCertificate {
     if (arg.includeCa) data["includeCa"] = arg.includeCa;
     if (arg.exportFormat) data["exportFormat"] = arg.exportFormat;
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`certificatedistribution/exportcertificates`, data)
       .then((res) => {
         return res.status;

--- a/src/CompositeTrigger.ts
+++ b/src/CompositeTrigger.ts
@@ -13,8 +13,8 @@ export interface IClassCompositeTrigger {
 }
 
 export class CompositeTrigger implements IClassCompositeTrigger {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: ICompositeEvent;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -24,21 +24,21 @@ export class CompositeTrigger implements IClassCompositeTrigger {
     if (!id)
       throw new Error(`compositeTrigger.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details as ICompositeEvent;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`compositeevent/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`compositeevent/${this.#id}`)
         .then((res) => res.data as ICompositeEvent);
     }
   }
 
   async remove() {
-    return await this.repoClient
+    return await this.#repoClient
       .Delete(`compositeevent/${this.details.id}`)
       .then((r) => {
         return { id: this.details.id, status: r.status } as IEntityRemove;
@@ -73,7 +73,7 @@ export class CompositeTrigger implements IClassCompositeTrigger {
           }
 
           // if task id is not specified then find the id based on the provided name
-          const task = await this.repoClient
+          const task = await this.#repoClient
             .Get(`task?filter=(name eq '${r.name}')`)
             .then((t) => t.data as ITask[]);
 
@@ -95,7 +95,7 @@ export class CompositeTrigger implements IClassCompositeTrigger {
       );
     }
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`compositeevent/${this.details.id}`, this.details)
       .then((res) => res.data as ICompositeEvent);
   }

--- a/src/ContentLibraries.ts
+++ b/src/ContentLibraries.ts
@@ -77,14 +77,14 @@ export interface IClassContentLibraries {
 }
 
 export class ContentLibraries implements IClassContentLibraries {
-  private repoClient: QlikRepositoryClient;
-  private genericClient: QlikGenericRestClient;
+  #repoClient: QlikRepositoryClient;
+  #genericClient: QlikGenericRestClient;
   constructor(
     private mainRepoClient: QlikRepositoryClient,
     private mainGenericClient: QlikGenericRestClient
   ) {
-    this.repoClient = mainRepoClient;
-    this.genericClient = mainGenericClient;
+    this.#repoClient = mainRepoClient;
+    this.#genericClient = mainGenericClient;
   }
 
   public async create(arg: IContentLibraryCreate) {
@@ -92,7 +92,7 @@ export class ContentLibraries implements IClassContentLibraries {
       throw new Error(`contentLibrary.create: "name" parameter is required`);
 
     let getCommonProps = new GetCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       arg.customProperties || [],
       arg.tags || [],
       arg.owner || ""
@@ -100,11 +100,12 @@ export class ContentLibraries implements IClassContentLibraries {
 
     let commonProps = await getCommonProps.getAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`contentlibrary`, { name: arg.name, ...commonProps })
       .then((res) => res.data as IContentLibrary)
       .then(
-        (t) => new ContentLibrary(this.repoClient, t.id, t, this.genericClient)
+        (t) =>
+          new ContentLibrary(this.#repoClient, t.id, t, this.#genericClient)
       );
   }
 
@@ -112,10 +113,10 @@ export class ContentLibraries implements IClassContentLibraries {
     if (!arg.id)
       throw new Error(`contentLibraries.get: "id" parameter is required`);
     const cl: ContentLibrary = new ContentLibrary(
-      this.repoClient,
+      this.#repoClient,
       arg.id,
       null,
-      this.genericClient
+      this.#genericClient
     );
     await cl.init();
 
@@ -123,16 +124,16 @@ export class ContentLibraries implements IClassContentLibraries {
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`contentlibrary/full`)
       .then((res) => res.data as IContentLibrary[])
       .then((data) => {
         return data.map((t) => {
           return new ContentLibrary(
-            this.repoClient,
+            this.#repoClient,
             t.id,
             t,
-            this.genericClient
+            this.#genericClient
           );
         });
       });
@@ -148,16 +149,16 @@ export class ContentLibraries implements IClassContentLibraries {
     urlBuild.addParam("filter", arg.filter);
     urlBuild.addParam("orderby", arg.orderBy);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(urlBuild.getUrl())
       .then((res) => res.data as IContentLibrary[])
       .then((data) => {
         return data.map((t) => {
           return new ContentLibrary(
-            this.repoClient,
+            this.#repoClient,
             t.id,
             t,
-            this.genericClient
+            this.#genericClient
           );
         });
       });
@@ -179,14 +180,14 @@ export class ContentLibraries implements IClassContentLibraries {
     urlBuild.addParam("overwrite", arg.overwrite || undefined);
 
     const mimeType = getMime(arg.file);
-    return await this.repoClient
+    return await this.#repoClient
       .Put(urlBuild.getUrl(), {}, mimeType)
       .then((res) => {
         return new ContentLibrary(
-          this.repoClient,
+          this.#repoClient,
           (res.data as IContentLibrary).id,
           res.data as IContentLibrary,
-          this.genericClient
+          this.#genericClient
         );
       });
   }
@@ -207,11 +208,12 @@ export class ContentLibraries implements IClassContentLibraries {
     urlBuild.addParam("overwrite", arg.overwrite || undefined);
 
     const mimeType = getMime(arg.file);
-    return await this.repoClient
+    return await this.#repoClient
       .Put(urlBuild.getUrl(), {}, mimeType)
       .then((res) => res.data as IContentLibrary)
       .then(
-        (a) => new ContentLibrary(this.repoClient, a.id, a, this.genericClient)
+        (a) =>
+          new ContentLibrary(this.#repoClient, a.id, a, this.#genericClient)
       );
   }
 
@@ -234,7 +236,7 @@ export class ContentLibraries implements IClassContentLibraries {
     const urlBuild = new URLBuild(`selection/contentlibrary`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/ContentLibrary.ts
+++ b/src/ContentLibrary.ts
@@ -22,9 +22,9 @@ export interface IClassContentLibrary {
 }
 
 export class ContentLibrary implements IClassContentLibrary {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
-  private genericClient: QlikGenericRestClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
+  #genericClient: QlikGenericRestClient;
   details: IContentLibrary;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -34,16 +34,16 @@ export class ContentLibrary implements IClassContentLibrary {
   ) {
     if (!id) throw new Error(`contentLibrary.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
-    this.genericClient = genericClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
+    this.#genericClient = genericClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`contentlibrary/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`contentlibrary/${this.#id}`)
         .then((res) => res.data as IContentLibrary);
     }
   }
@@ -52,8 +52,8 @@ export class ContentLibrary implements IClassContentLibrary {
     let files: IStaticContentReferenceCondensed[] = [];
 
     if (
-      this.repoClient.configFull.port &&
-      this.repoClient.configFull.port == 4242
+      this.#repoClient.configFull.port &&
+      this.#repoClient.configFull.port == 4242
     )
       throw new Error(
         `contentLibrary.export: exporting content library is not possible when the authentication is made with certificates`
@@ -77,7 +77,7 @@ export class ContentLibrary implements IClassContentLibrary {
       files.map(async (f) => {
         const logicalPath =
           f.logicalPath[0] == "/" ? f.logicalPath.substr(1) : f.logicalPath;
-        const fileContent = await this.genericClient.Get(logicalPath);
+        const fileContent = await this.#genericClient.Get(logicalPath);
         return {
           name: f.logicalPath.replace(/^.*[\\\/]/, ""),
           file: fileContent.data,
@@ -87,7 +87,7 @@ export class ContentLibrary implements IClassContentLibrary {
   }
 
   public async remove() {
-    return await this.repoClient
+    return await this.#repoClient
       .Delete(`contentlibrary/${this.details.id}`)
       .then((res) => res.status);
   }
@@ -97,7 +97,7 @@ export class ContentLibrary implements IClassContentLibrary {
     options?: IUpdateObjectOptions
   ) {
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
@@ -107,7 +107,7 @@ export class ContentLibrary implements IClassContentLibrary {
 
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`contentlibrary/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IContentLibrary);
   }

--- a/src/CustomProperties.ts
+++ b/src/CustomProperties.ts
@@ -79,27 +79,27 @@ export interface IClassCustomProperties {
 }
 
 export class CustomProperties implements IClassCustomProperties {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id)
       throw new Error(`customProperty.get: "id" parameter is required`);
 
-    const cp: CustomProperty = new CustomProperty(this.repoClient, arg.id);
+    const cp: CustomProperty = new CustomProperty(this.#repoClient, arg.id);
     await cp.init();
 
     return cp;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`custompropertydefinition/full`)
       .then((res) => res.data as ICustomProperty[])
       .then((data) => {
-        return data.map((t) => new CustomProperty(this.repoClient, t.id, t));
+        return data.map((t) => new CustomProperty(this.#repoClient, t.id, t));
       });
   }
 
@@ -109,7 +109,7 @@ export class CustomProperties implements IClassCustomProperties {
         `customProperty.getFilter: "filter" parameter is required`
       );
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(
         `custompropertydefinition/full?filter=(${encodeURIComponent(
           arg.filter
@@ -117,7 +117,7 @@ export class CustomProperties implements IClassCustomProperties {
       )
       .then((res) => res.data as ICustomProperty[])
       .then((data) => {
-        return data.map((t) => new CustomProperty(this.repoClient, t.id, t));
+        return data.map((t) => new CustomProperty(this.#repoClient, t.id, t));
       });
   }
 
@@ -130,7 +130,7 @@ export class CustomProperties implements IClassCustomProperties {
         `customProperty.create: "name" should be alphanumeric value`
       );
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(
         `custompropertydefinition`,
         {
@@ -143,7 +143,7 @@ export class CustomProperties implements IClassCustomProperties {
         "application/json"
       )
       .then((res) => res.data as ICustomProperty)
-      .then((c) => new CustomProperty(this.repoClient, c.id, c));
+      .then((c) => new CustomProperty(this.#repoClient, c.id, c));
   }
 
   public async removeFilter(arg: { filter: string }) {
@@ -164,7 +164,7 @@ export class CustomProperties implements IClassCustomProperties {
     const urlBuild = new URLBuild(`selection/custompropertydefinition`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/CustomProperty.ts
+++ b/src/CustomProperty.ts
@@ -10,8 +10,8 @@ export interface IClassCustomProperty {
 }
 
 export class CustomProperty implements IClassCustomProperty {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: ICustomProperty;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -20,22 +20,22 @@ export class CustomProperty implements IClassCustomProperty {
   ) {
     if (!id) throw new Error(`customProperty.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`custompropertydefinition/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`custompropertydefinition/${this.#id}`)
         .then((res) => res.data as ICustomProperty);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`custompropertydefinition/${this.id}`)
+    return await this.#repoClient
+      .Delete(`custompropertydefinition/${this.#id}`)
       .then((res) => res.status);
   }
 
@@ -55,7 +55,7 @@ export class CustomProperty implements IClassCustomProperty {
 
     this.details.modifiedDate = modifiedDateTime();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`custompropertydefinition/${this.details.id}`, this.details)
       .then((res) => res.data as ICustomProperty);
   }

--- a/src/DataConnection.ts
+++ b/src/DataConnection.ts
@@ -13,8 +13,8 @@ export interface IClassDataConnection {
 }
 
 export class DataConnection implements IClassDataConnection {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: IDataConnection;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -23,21 +23,21 @@ export class DataConnection implements IClassDataConnection {
   ) {
     if (!id) throw new Error(`dataConnections.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`dataconnection/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`dataconnection/${this.#id}`)
         .then((res) => res.data as IDataConnection);
     }
   }
 
   async remove() {
-    return await this.repoClient
+    return await this.#repoClient
       .Delete(`dataconnection/${this.details.id}`)
       .then((res) => res.status);
   }
@@ -47,14 +47,14 @@ export class DataConnection implements IClassDataConnection {
     options?: IUpdateObjectOptions
   ) {
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`dataconnection/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IDataConnection);
   }

--- a/src/DataConnections.ts
+++ b/src/DataConnections.ts
@@ -70,9 +70,9 @@ export interface IClassDataConnections {
 }
 
 export class DataConnections implements IClassDataConnections {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
@@ -80,7 +80,7 @@ export class DataConnections implements IClassDataConnections {
       throw new Error(`dataConnections.get: "id" parameter is required`);
 
     const dc: DataConnection = new DataConnection(
-      this.repoClient,
+      this.#repoClient,
       arg.id,
       null
     );
@@ -90,11 +90,11 @@ export class DataConnections implements IClassDataConnections {
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`dataconnection/full`)
       .then((res) => res.data as IDataConnection[])
       .then((data) => {
-        return data.map((t) => new DataConnection(this.repoClient, t.id, t));
+        return data.map((t) => new DataConnection(this.#repoClient, t.id, t));
       });
   }
 
@@ -108,11 +108,11 @@ export class DataConnections implements IClassDataConnections {
     urlBuild.addParam("filter", arg.filter);
     urlBuild.addParam("orderby", arg.orderBy);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(urlBuild.getUrl())
       .then((res) => res.data as IDataConnection[])
       .then((data) => {
-        return data.map((t) => new DataConnection(this.repoClient, t.id, t));
+        return data.map((t) => new DataConnection(this.#repoClient, t.id, t));
       });
   }
 
@@ -134,7 +134,7 @@ export class DataConnections implements IClassDataConnections {
     const urlBuild = new URLBuild(`selection/dataconnection`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }
@@ -168,7 +168,7 @@ export class DataConnections implements IClassDataConnections {
     // data["engineObjectId"] = uuid();
 
     let getCommonProps = new GetCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       arg.customProperties,
       arg.tags,
       arg.owner
@@ -177,9 +177,9 @@ export class DataConnections implements IClassDataConnections {
     let commonProps = await getCommonProps.getAll();
     let d = { ...data, ...commonProps };
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`dataconnection`, { ...data, ...commonProps })
       .then((res) => res.data as IDataConnection)
-      .then((d) => new DataConnection(this.repoClient, d.id, d));
+      .then((d) => new DataConnection(this.#repoClient, d.id, d));
   }
 }

--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -10,21 +10,21 @@ export interface IClassEngine {
 }
 
 export class Engine implements IClassEngine {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: IEngine;
   constructor(repoClient: QlikRepositoryClient, id: string, details?: IEngine) {
     if (!id) throw new Error(`engine.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`engineservice/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`engineservice/${this.#id}`)
         .then((res) => res.data as IEngine);
     }
   }
@@ -273,7 +273,7 @@ export class Engine implements IClassEngine {
 
     this.details.modifiedDate = modifiedDateTime();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`engineservice/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IEngine);
   }

--- a/src/Engines.ts
+++ b/src/Engines.ts
@@ -100,25 +100,25 @@ export interface IClassEngines {
 }
 
 export class Engines implements IClassEngines {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id) throw new Error(`engines.get: "id" parameter is required`);
-    const engine: Engine = new Engine(this.repoClient, arg.id);
+    const engine: Engine = new Engine(this.#repoClient, arg.id);
     await engine.init();
 
     return engine;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`engineservice/full`)
       .then((res) => res.data as IEngine[])
       .then((data) => {
-        return data.map((t) => new Engine(this.repoClient, t.id, t));
+        return data.map((t) => new Engine(this.#repoClient, t.id, t));
       });
   }
 
@@ -137,7 +137,7 @@ export class Engines implements IClassEngines {
       loadBalancingPurpose: loadBalancingPurpose,
     };
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`loadbalancing/validengines"`, body)
       .then((res) => res.data as IEngineGetValidResult[]);
   }
@@ -147,11 +147,11 @@ export class Engines implements IClassEngines {
 
     let baseUrl = `engineservice/full`;
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`${baseUrl}?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as IEngine[])
       .then((data) => {
-        return data.map((t) => new Engine(this.repoClient, t.id, t));
+        return data.map((t) => new Engine(this.#repoClient, t.id, t));
       });
   }
 
@@ -159,7 +159,7 @@ export class Engines implements IClassEngines {
     const urlBuild = new URLBuild(`selection/engineservice`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -13,8 +13,8 @@ export interface IClassExtension {
 }
 
 export class Extension implements IClassExtension {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: IExtension;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -23,35 +23,35 @@ export class Extension implements IClassExtension {
   ) {
     if (!id) throw new Error(`extension.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`extension/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`extension/${this.#id}`)
         .then((res) => res.data as IExtension);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`extension/${this.id}`)
+    return await this.#repoClient
+      .Delete(`extension/${this.#id}`)
       .then((res) => res.status);
   }
 
   public async update(arg: IExtensionUpdate, options?: IUpdateObjectOptions) {
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`extension/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IExtension);
   }

--- a/src/Extensions.ts
+++ b/src/Extensions.ts
@@ -54,25 +54,25 @@ export interface IClassExtensions {
 }
 
 export class Extensions implements IClassExtensions {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id) throw new Error(`extension.get: "id" parameter is required`);
-    const extension: Extension = new Extension(this.repoClient, arg.id, null);
+    const extension: Extension = new Extension(this.#repoClient, arg.id, null);
     await extension.init();
 
     return extension;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`extension/full`)
       .then((res) => res.data as IExtension[])
       .then((data) => {
-        return data.map((t) => new Extension(this.repoClient, t.id, t));
+        return data.map((t) => new Extension(this.#repoClient, t.id, t));
       });
   }
 
@@ -80,11 +80,11 @@ export class Extensions implements IClassExtensions {
     if (!arg.filter)
       throw new Error(`extension.getFilter: "filter" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`extension?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as IExtension[])
       .then((data) => {
-        return data.map((t) => new Extension(this.repoClient, t.id, t));
+        return data.map((t) => new Extension(this.#repoClient, t.id, t));
       });
   }
 
@@ -108,7 +108,7 @@ export class Extensions implements IClassExtensions {
     const urlBuild = new URLBuild(`selection/extension`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }
@@ -120,11 +120,11 @@ export class Extensions implements IClassExtensions {
     const urlBuild = new URLBuild(`extension/upload`);
     if (arg.password) urlBuild.addParam("password", arg.password);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), arg.file)
       .then((res) => {
         return new Extension(
-          this.repoClient,
+          this.#repoClient,
           (res.data[0] as IExtension).id,
           res.data[0]
         );

--- a/src/ExternalTasks.ts
+++ b/src/ExternalTasks.ts
@@ -20,27 +20,27 @@ export interface IClassExternalTasks {
 }
 
 export class ExternalTasks implements IClassExternalTasks {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id) throw new Error(`reloadTasks.get: "id" parameter is required`);
 
-    const extTask: ExternalTask = new ExternalTask(this.repoClient, arg.id);
+    const extTask: ExternalTask = new ExternalTask(this.#repoClient, arg.id);
     await extTask.init();
 
     return extTask;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`externalprogramtask/full`)
       .then((res) => res.data as ITask[])
       .then((data) => {
         return data.map((t) => {
-          return new ExternalTask(this.repoClient, t.id, t);
+          return new ExternalTask(this.#repoClient, t.id, t);
         });
       });
   }
@@ -49,14 +49,14 @@ export class ExternalTasks implements IClassExternalTasks {
     if (!arg.filter)
       throw new Error(`reloadTasks.getFilter: "path" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(
         `externalprogramtask/full?filter=(${encodeURIComponent(arg.filter)})`
       )
       .then((res) => res.data as ITask[])
       .then((data) => {
         return data.map((t) => {
-          return new ExternalTask(this.repoClient, t.id, t);
+          return new ExternalTask(this.#repoClient, t.id, t);
         });
       });
   }
@@ -65,7 +65,7 @@ export class ExternalTasks implements IClassExternalTasks {
     let url: string = `externalprogramtask/count`;
     if (arg.filter) url += `${url}?filter=(${encodeURIComponent(arg.filter)})`;
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`${url}`)
       .then((res) => res.data.value as number);
   }
@@ -88,7 +88,7 @@ export class ExternalTasks implements IClassExternalTasks {
     const urlBuild = new URLBuild(`selection/externalprogramtask`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }
@@ -115,7 +115,7 @@ export class ExternalTasks implements IClassExternalTasks {
     };
 
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       reloadTask,
       arg
     );
@@ -128,9 +128,9 @@ export class ExternalTasks implements IClassExternalTasks {
     delete (reloadTask as any).customProperties;
     delete (reloadTask as any).tags;
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`reloadtask/create`, { ...reloadTask })
       .then((res) => res.data as ITask)
-      .then((t) => new ExternalTask(this.repoClient, t.id, t));
+      .then((t) => new ExternalTask(this.#repoClient, t.id, t));
   }
 }

--- a/src/License.ts
+++ b/src/License.ts
@@ -36,19 +36,19 @@ export interface IClassLicense {
 }
 
 export class License implements IClassLicense {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async accessTypeInfoGet() {
-    return await this.repoClient.Get(`license/accesstypeinfo`).then((res) => {
+    return await this.#repoClient.Get(`license/accesstypeinfo`).then((res) => {
       return res.data as IAccessTypeInfo;
     });
   }
 
   public async get() {
-    return await this.repoClient.Get(`license`).then((res) => {
+    return await this.#repoClient.Get(`license`).then((res) => {
       return res.data as ILicense;
     });
   }
@@ -83,7 +83,7 @@ export class License implements IClassLicense {
 
     url += `?control=${arg.control}`;
 
-    return await this.repoClient[method](url, data).then((res) => {
+    return await this.#repoClient[method](url, data).then((res) => {
       return res.data as ILicense;
     });
   }
@@ -109,7 +109,7 @@ export class License implements IClassLicense {
 
     data["key"] = arg.key;
 
-    return await this.repoClient[method](url, data).then((res) => {
+    return await this.#repoClient[method](url, data).then((res) => {
       return res.data as ILicense;
     });
   }
@@ -119,7 +119,7 @@ export class License implements IClassLicense {
 
     if (arg.resourceId) data.resourceFilter = `id eq ${arg.resourceId}`;
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`systemrule/license/audit`, data)
       .then((res) => res.data as IAudit);
   }
@@ -128,7 +128,7 @@ export class License implements IClassLicense {
     let url = `license/${arg.accessType}AccessType`;
     if (arg.id) url += `/${arg.id}`;
 
-    return await this.repoClient.Get(url).then((res: IHttpReturn) => {
+    return await this.#repoClient.Get(url).then((res: IHttpReturn) => {
       if (res.data.length > 0) return res.data as ILicenseAccessTypeCondensed[];
 
       return [res.data];
@@ -143,7 +143,7 @@ export class License implements IClassLicense {
 
     let url = `license/${arg.accessType}AccessType/${arg.id}`;
 
-    return await this.repoClient
+    return await this.#repoClient
       .Delete(url)
       .then((res: IHttpReturn) => res.status);
   }
@@ -157,7 +157,7 @@ export class License implements IClassLicense {
         `license.accessGroupCreateUser: "name" parameter is required`
       );
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`license/${arg.accessType}AccessGroup`, { name: arg.name })
       .then((res) => {
         return res.data as ILicenseAccessGroup;

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -14,8 +14,8 @@ export interface IClassNode {
 }
 
 export class Node implements IClassNode {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: IServerNodeConfiguration;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -24,22 +24,22 @@ export class Node implements IClassNode {
   ) {
     if (!id) throw new Error(`node.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`servernodeconfiguration/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`servernodeconfiguration/${this.#id}`)
         .then((res) => res.data as IServerNodeConfiguration);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`servernodeconfiguration/${this.id}`)
+    return await this.#repoClient
+      .Delete(`servernodeconfiguration/${this.#id}`)
       .then((res) => res.status);
   }
 
@@ -70,20 +70,20 @@ export class Node implements IClassNode {
     }
 
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`servernodeconfiguration/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IServerNodeConfiguration);
   }
 
   public async setCentral() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`failover/tonode/${this.details.id}`)
       .then((res) => res.status);
   }

--- a/src/Nodes.ts
+++ b/src/Nodes.ts
@@ -97,18 +97,18 @@ export interface IClassNodes {
 }
 
 export class Nodes implements IClassNodes {
-  private repoClient: QlikRepositoryClient;
-  private genericClient: QlikGenericRestClient;
+  #repoClient: QlikRepositoryClient;
+  #genericClient: QlikGenericRestClient;
   constructor(
     private mainRepoClient: QlikRepositoryClient,
     private mainGenericClient: QlikGenericRestClient
   ) {
-    this.repoClient = mainRepoClient;
-    this.genericClient = mainGenericClient;
+    this.#repoClient = mainRepoClient;
+    this.#genericClient = mainGenericClient;
   }
 
   public async count(): Promise<number> {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`servernodeconfiguration/count`)
       .then((res) => res.data as number);
   }
@@ -145,25 +145,25 @@ export class Nodes implements IClassNodes {
 
     const container = await this.createNewNode(nodeConfig);
 
-    const node = new Node(this.repoClient, container.id);
+    const node = new Node(this.#repoClient, container.id);
     await node.init();
     return node;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id) throw new Error(`node.get: "id" parameter is required`);
-    const node: Node = new Node(this.repoClient, arg.id);
+    const node: Node = new Node(this.#repoClient, arg.id);
     await node.init();
 
     return node;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`servernodeconfiguration/full`)
       .then((res) => res.data as IServerNodeConfiguration[])
       .then((data) => {
-        return data.map((t) => new Node(this.repoClient, t.id, t));
+        return data.map((t) => new Node(this.#repoClient, t.id, t));
       });
   }
 
@@ -171,7 +171,7 @@ export class Nodes implements IClassNodes {
     if (!arg.filter)
       throw new Error(`node.getFilter: "filter" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(
         `servernodeconfiguration/full?filter=(${encodeURIComponent(
           arg.filter
@@ -179,18 +179,18 @@ export class Nodes implements IClassNodes {
       )
       .then((res) => res.data as IServerNodeConfiguration[])
       .then((data) => {
-        return data.map((t) => new Node(this.repoClient, t.id, t));
+        return data.map((t) => new Node(this.#repoClient, t.id, t));
       });
   }
 
   public async register(arg: INodeCreate) {
     const node = await this.createNewNode(arg);
 
-    const registration = await this.repoClient
+    const registration = await this.#repoClient
       .Get(`servernoderegistration/start/${node.id}`)
       .then((n) => n.data as IServerNodeConfiguration);
 
-    return await this.genericClient
+    return await this.#genericClient
       .Post(`http://localhost:4570/certificateSetup`, registration)
       .then((res) => res.status);
   }
@@ -211,7 +211,7 @@ export class Nodes implements IClassNodes {
     const urlBuild = new URLBuild(`selection/servernodeconfiguration`);
     urlBuild.addParam("filter", filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }
@@ -248,7 +248,7 @@ export class Nodes implements IClassNodes {
       if (arg.nodePurpose == "Both") nodeConfig.configuration.nodePurpose = 2;
     }
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`servernodeconfiguration/container`, nodeConfig)
       .then((c) => c.data.configuration as IServerNodeConfigurationCondensed);
   }

--- a/src/Privileges.ts
+++ b/src/Privileges.ts
@@ -35,9 +35,9 @@ export interface IClassPrivileges {
 }
 
 export class Privileges implements IClassPrivileges {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { item: IObject; filter?: string }) {
@@ -46,7 +46,7 @@ export class Privileges implements IClassPrivileges {
     let url = `${arg.item.schemaPath}`;
     if (arg.filter) url += `/?privilegesFilter=${arg.filter}`;
 
-    return await this.repoClient.Post(url, arg.item).then((res) => {
+    return await this.#repoClient.Post(url, arg.item).then((res) => {
       return res.data as string[];
     });
   }

--- a/src/Proxies.ts
+++ b/src/Proxies.ts
@@ -33,10 +33,10 @@ export interface IClassProxies {
 }
 
 export class Proxies implements IClassProxies {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   private node: IClassNodes;
   constructor(private mainRepoClient: QlikRepositoryClient, node: IClassNodes) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
     this.node = node;
   }
 
@@ -46,33 +46,33 @@ export class Proxies implements IClassProxies {
       throw new Error(`proxy.add: "virtualProxyId" is required`);
 
     let proxy = await this.get({ id: arg.proxyId });
-    const virtualProxyInstance = new VirtualProxies(this.repoClient);
+    const virtualProxyInstance = new VirtualProxies(this.#repoClient);
     let virtualProxy = await virtualProxyInstance.get({
       id: arg.virtualProxyId,
     });
 
     proxy.details.settings.virtualProxies.push(virtualProxy.details);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`proxyservice/${arg.proxyId}`, proxy)
       .then((res) => res.data as IProxyService)
-      .then((s) => new Proxy(this.repoClient, s.id, s));
+      .then((s) => new Proxy(this.#repoClient, s.id, s));
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id) throw new Error(`proxy.get: "id" parameter is required`);
-    const proxy: Proxy = new Proxy(this.repoClient, arg.id);
+    const proxy: Proxy = new Proxy(this.#repoClient, arg.id);
     await proxy.init();
 
     return proxy;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`proxyservice/full`)
       .then((res) => res.data as IProxyService[])
       .then((data) => {
-        return data.map((t) => new Proxy(this.repoClient, t.id, t));
+        return data.map((t) => new Proxy(this.#repoClient, t.id, t));
       });
   }
 
@@ -80,11 +80,11 @@ export class Proxies implements IClassProxies {
     if (!arg.filter)
       throw new Error(`proxy.getFilter: "filter" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`proxyservice/full?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as IProxyService[])
       .then((data) => {
-        return data.map((t) => new Proxy(this.repoClient, t.id, t));
+        return data.map((t) => new Proxy(this.#repoClient, t.id, t));
       });
   }
 
@@ -92,7 +92,7 @@ export class Proxies implements IClassProxies {
     const urlBuild = new URLBuild(`selection/proxyservice`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }
@@ -171,9 +171,9 @@ export class Proxies implements IClassProxies {
     if (arg.oidcAttributeMap)
       data["oidcAttributeMap"] = parseOidcAttributeMap(arg.oidcAttributeMap);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`virtualproxyconfig`, { ...data })
-      .then((res) => new Proxy(this.repoClient, res.data.id, res.data));
+      .then((res) => new Proxy(this.#repoClient, res.data.id, res.data));
   }
 
   // // TODO: this might not be needed. leaving here just in case
@@ -185,7 +185,7 @@ export class Proxies implements IClassProxies {
   //   if (!virtualProxyId)
   //     throw new Error(`proxy.virtualProxyAdd: "virtualProxyId" is required`);
 
-  //   const virtualProxyInstance = new VirtualProxies(this.repoClient);
+  //   const virtualProxyInstance = new VirtualProxies(this.#repoClient);
   //   const virtualProxy = await virtualProxyInstance.get(virtualProxyId);
 
   //   return virtualProxy.details;

--- a/src/Proxy.ts
+++ b/src/Proxy.ts
@@ -16,8 +16,8 @@ export interface IClassProxy {
 }
 
 export class Proxy implements IClassProxy {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: IProxyService;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -26,15 +26,15 @@ export class Proxy implements IClassProxy {
   ) {
     if (!id) throw new Error(`proxy.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`proxyService/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`proxyService/${this.#id}`)
         .then((res) => res.data as IProxyService);
     }
   }
@@ -73,14 +73,14 @@ export class Proxy implements IClassProxy {
       );
 
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`proxyservice/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IProxyService);
   }
@@ -129,7 +129,7 @@ export class Proxy implements IClassProxy {
   private async parseVirtualProxies(
     vpArg: string[]
   ): Promise<IVirtualProxyConfigCondensed[]> {
-    let allVP = await this.repoClient.Get(`proxyservice/full`);
+    let allVP = await this.#repoClient.Get(`proxyservice/full`);
     let vpToAdd = allVP.data.filter((v: any) => {
       return vpArg.includes(v.prefix);
     });

--- a/src/ReloadTask.ts
+++ b/src/ReloadTask.ts
@@ -3,7 +3,9 @@ import { ITask } from "./Task.interface";
 import { ReloadTaskBase } from "./ReloadTaskBase";
 
 export class ReloadTask extends ReloadTaskBase {
+  // #repoClient: QlikRepositoryClient;
   constructor(repoClient: QlikRepositoryClient, id: string, details?: ITask) {
     super(repoClient, id, "reloadtask", details);
+    // this.#repoClient = repoClient;
   }
 }

--- a/src/ReloadTasks.ts
+++ b/src/ReloadTasks.ts
@@ -21,27 +21,27 @@ export interface IClassReloadTasks {
 }
 
 export class ReloadTasks implements IClassReloadTasks {
-  private repoClient: QlikRepositoryClient;
-  private genericClient: QlikGenericRestClient;
+  #repoClient: QlikRepositoryClient;
+  #genericClient: QlikGenericRestClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id) throw new Error(`reloadTasks.get: "id" parameter is required`);
 
-    const reloadTask: ReloadTask = new ReloadTask(this.repoClient, arg.id);
+    const reloadTask: ReloadTask = new ReloadTask(this.#repoClient, arg.id);
     await reloadTask.init();
 
     return reloadTask;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`reloadtask/full`)
       .then((res) => res.data as ITask[])
       .then((data) => {
-        return data.map((t) => new ReloadTask(this.repoClient, t.id, t));
+        return data.map((t) => new ReloadTask(this.#repoClient, t.id, t));
       });
   }
 
@@ -49,11 +49,11 @@ export class ReloadTasks implements IClassReloadTasks {
     if (!arg.filter)
       throw new Error(`reloadTasks.getFilter: "path" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`reloadtask/full?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as ITask[])
       .then((data) => {
-        return data.map((t) => new ReloadTask(this.repoClient, t.id, t));
+        return data.map((t) => new ReloadTask(this.#repoClient, t.id, t));
       });
   }
 
@@ -61,7 +61,7 @@ export class ReloadTasks implements IClassReloadTasks {
     let url: string = `reloadtask/count`;
     if (arg.filter) url += `${url}?filter=(${encodeURIComponent(arg.filter)})`;
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`${url}`)
       .then((res) => res.data.value as number);
   }
@@ -84,7 +84,7 @@ export class ReloadTasks implements IClassReloadTasks {
     const urlBuild = new URLBuild(`selection/reloadtask`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }
@@ -95,7 +95,7 @@ export class ReloadTasks implements IClassReloadTasks {
     const app = await getAppForReloadTask(
       arg.appId,
       arg.appFilter,
-      this.repoClient
+      this.#repoClient
     );
 
     let reloadTask: { [k: string]: any } = {};
@@ -114,7 +114,7 @@ export class ReloadTasks implements IClassReloadTasks {
     };
 
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       reloadTask,
       arg
     );
@@ -127,9 +127,9 @@ export class ReloadTasks implements IClassReloadTasks {
     delete (reloadTask as any).customProperties;
     delete (reloadTask as any).tags;
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`reloadtask/create`, { ...reloadTask })
       .then((res) => res.data as ITask)
-      .then((t) => new ReloadTask(this.repoClient, t.id, t));
+      .then((t) => new ReloadTask(this.#repoClient, t.id, t));
   }
 }

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -13,8 +13,8 @@ export interface IClassScheduler {
 }
 
 export class Scheduler implements IClassScheduler {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: ISchedulerService;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -24,22 +24,22 @@ export class Scheduler implements IClassScheduler {
     if (!id)
       throw new Error(`schedulerservice.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`schedulerservice/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`schedulerservice/${this.#id}`)
         .then((res) => res.data as ISchedulerService);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`schedulerservice/${this.id}`)
+    return await this.#repoClient
+      .Delete(`schedulerservice/${this.#id}`)
       .then((res) => res.status);
   }
 
@@ -74,14 +74,14 @@ export class Scheduler implements IClassScheduler {
     }
 
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`schedulerservice/${this.details.id}`, this.details)
       .then((res) => res.data as ISchedulerService);
   }

--- a/src/Schedulers.ts
+++ b/src/Schedulers.ts
@@ -62,25 +62,25 @@ export interface IClassSchedulers {
 }
 
 export class Schedulers implements IClassSchedulers {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id) throw new Error(`scheduler.get: "id" parameter is required`);
-    const scheduler: Scheduler = new Scheduler(this.repoClient, arg.id);
+    const scheduler: Scheduler = new Scheduler(this.#repoClient, arg.id);
     await scheduler.init();
 
     return scheduler;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`schedulerservice/full`)
       .then((res) => res.data as ISchedulerService[])
       .then((data) => {
-        return data.map((t) => new Scheduler(this.repoClient, t.id, t));
+        return data.map((t) => new Scheduler(this.#repoClient, t.id, t));
       });
   }
 
@@ -88,11 +88,11 @@ export class Schedulers implements IClassSchedulers {
     if (!arg.filter)
       throw new Error(`scheduler.getFilter: "filter" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`schedulerservice/full?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as ISchedulerService[])
       .then((data) => {
-        return data.map((t) => new Scheduler(this.repoClient, t.id, t));
+        return data.map((t) => new Scheduler(this.#repoClient, t.id, t));
       });
   }
 
@@ -114,7 +114,7 @@ export class Schedulers implements IClassSchedulers {
     const urlBuild = new URLBuild(`selection/schedulerservice`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/SchemaTrigger.ts
+++ b/src/SchemaTrigger.ts
@@ -11,8 +11,8 @@ export interface IClassSchemaTrigger {
 }
 
 export class SchemaTrigger implements IClassSchemaTrigger {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: ISchemaEvent;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -21,21 +21,21 @@ export class SchemaTrigger implements IClassSchemaTrigger {
   ) {
     if (!id) throw new Error(`schemaTrigger.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details as ISchemaEvent;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`schemaevent/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`schemaevent/${this.#id}`)
         .then((res) => res.data as ISchemaEvent);
     }
   }
 
   async remove() {
-    return await this.repoClient
+    return await this.#repoClient
       .Delete(`schemaevent/${this.details.id}`)
       .then((r) => {
         return { id: this.details.id, status: r.status } as IEntityRemove;
@@ -65,7 +65,7 @@ export class SchemaTrigger implements IClassSchemaTrigger {
       this.details.incrementDescription = schemaRepeatOpt.incrementDescr;
     }
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`schemaevent/${this.details.id}`, this.details)
       .then((res) => res.data as ISchemaEvent);
   }

--- a/src/Selection.ts
+++ b/src/Selection.ts
@@ -8,12 +8,12 @@ export interface IClassSelection {
 }
 
 export class Selection implements IClassSelection {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   private area: string;
   details: ISelection;
   constructor(repoClient: QlikRepositoryClient, area: string) {
     this.area = area;
-    this.repoClient = repoClient;
+    this.#repoClient = repoClient;
     this.details = {} as ISelection;
   }
 
@@ -22,7 +22,7 @@ export class Selection implements IClassSelection {
       const urlBuild = new URLBuild(`selection/${this.area}`);
       urlBuild.addParam("filter", filter);
 
-      this.details = await this.repoClient
+      this.details = await this.#repoClient
         .Post(`${urlBuild.getUrl()}`, {})
         .then((res) => res.data as ISelection);
     }
@@ -32,13 +32,13 @@ export class Selection implements IClassSelection {
     if (!arg.path)
       throw new Error(`selection.data: "path" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`selection/${this.details.id}/${arg.path}`)
       .then((res) => res.data);
   }
 
   public async remove() {
-    return await this.repoClient
+    return await this.#repoClient
       .Delete(`selection/${this.details.id}`)
       .then((res) => res.status);
   }

--- a/src/Selections.ts
+++ b/src/Selections.ts
@@ -90,16 +90,16 @@ export interface IClassSelections {
 }
 
 export class Selections implements IClassSelections {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async create(arg: { area: TSelectionAreas; filter?: string }) {
     if (!arg.area)
       throw new Error(`select.create: "area" parameter is required`);
 
-    const selection: Selection = new Selection(this.repoClient, arg.area);
+    const selection: Selection = new Selection(this.#repoClient, arg.area);
     await selection.init(arg.filter);
 
     return selection;

--- a/src/ServiceCluster.ts
+++ b/src/ServiceCluster.ts
@@ -12,8 +12,8 @@ export interface IClassServiceCluster {
 }
 
 export class ServiceCluster implements IClassServiceCluster {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: IServiceCluster;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -22,22 +22,22 @@ export class ServiceCluster implements IClassServiceCluster {
   ) {
     if (!id) throw new Error(`serviceClusters.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`ServiceCluster/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`ServiceCluster/${this.#id}`)
         .then((res) => res.data as IServiceCluster);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`ServiceCluster/${this.id}`)
+    return await this.#repoClient
+      .Delete(`ServiceCluster/${this.#id}`)
       .then((res) => res.status);
   }
 
@@ -77,7 +77,7 @@ export class ServiceCluster implements IClassServiceCluster {
       this.details.settings.sharedPersistenceProperties.failoverTimeout =
         arg.failoverTimeout;
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`ServiceCluster/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IServiceCluster);
   }

--- a/src/ServiceClusters.ts
+++ b/src/ServiceClusters.ts
@@ -15,13 +15,13 @@ export interface IClassServiceClusters {
 }
 
 export class ServiceClusters implements IClassServiceClusters {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async count() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`ServiceCluster/count`)
       .then((res) => res.data as number);
   }
@@ -30,18 +30,18 @@ export class ServiceClusters implements IClassServiceClusters {
     if (!arg.id)
       throw new Error(`serviceCluster.get: "id" parameter is required`);
 
-    const sc: ServiceCluster = new ServiceCluster(this.repoClient, arg.id);
+    const sc: ServiceCluster = new ServiceCluster(this.#repoClient, arg.id);
     await sc.init();
 
     return sc;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`ServiceCluster/full`)
       .then((res) => res.data as IServiceCluster[])
       .then((data) => {
-        return data.map((t) => new ServiceCluster(this.repoClient, t.id, t));
+        return data.map((t) => new ServiceCluster(this.#repoClient, t.id, t));
       });
   }
 
@@ -51,11 +51,11 @@ export class ServiceClusters implements IClassServiceClusters {
         `serviceCluster.getFilter: "filter" parameter is required`
       );
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`ServiceCluster/full?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as IServiceCluster[])
       .then((data) => {
-        return data.map((t) => new ServiceCluster(this.repoClient, t.id, t));
+        return data.map((t) => new ServiceCluster(this.#repoClient, t.id, t));
       });
   }
 
@@ -75,7 +75,7 @@ export class ServiceClusters implements IClassServiceClusters {
     const urlBuild = new URLBuild(`selection/ServiceCluster`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/ServiceStatus.ts
+++ b/src/ServiceStatus.ts
@@ -29,13 +29,13 @@ export interface IClassServiceStatus {
 }
 
 export class ServiceStatus implements IClassServiceStatus {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async count(): Promise<number> {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`ServiceStatus/count`)
       .then((res) => res.data as number);
   }
@@ -43,13 +43,13 @@ export class ServiceStatus implements IClassServiceStatus {
   public async get(arg: { id: string }) {
     if (!arg.id)
       throw new Error(`serviceStatus.get: "id" parameter is required`);
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`ServiceStatus/${arg.id}`)
       .then((res) => res.data as IServiceStatus);
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`ServiceStatus`)
       .then((res) => res.data as IServiceStatusCondensed[]);
   }
@@ -60,7 +60,7 @@ export class ServiceStatus implements IClassServiceStatus {
         `serviceStatus.getFilter: "filter" parameter is required`
       );
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`ServiceStatus/full?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as IServiceStatus[]);
   }
@@ -69,7 +69,7 @@ export class ServiceStatus implements IClassServiceStatus {
     const urlBuild = new URLBuild(`selection/ServiceStatus`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/SharedContent.ts
+++ b/src/SharedContent.ts
@@ -16,8 +16,8 @@ export interface IClassSharedContent {
 }
 
 export class SharedContent implements IClassSharedContent {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: ISharedContent;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -26,22 +26,22 @@ export class SharedContent implements IClassSharedContent {
   ) {
     if (!id) throw new Error(`sharedContent.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`sharedcontent/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`sharedcontent/${this.#id}`)
         .then((res) => res.data as ISharedContent);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`sharedcontent/${this.id}`)
+    return await this.#repoClient
+      .Delete(`sharedcontent/${this.#id}`)
       .then((res) => res.status);
   }
 
@@ -54,14 +54,14 @@ export class SharedContent implements IClassSharedContent {
     if (arg.type) this.details.type = arg.type;
 
     const updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`sharedcontent/${this.details.id}`, { ...this.details })
       .then((res) => res.data as ISharedContent);
   }
@@ -79,7 +79,7 @@ export class SharedContent implements IClassSharedContent {
     );
     urlBuild.addParam("externalpath", arg.externalPath);
 
-    const status = await this.repoClient
+    const status = await this.#repoClient
       .Post(urlBuild.getUrl(), arg.file)
       .then((res) => res.status);
 
@@ -102,7 +102,7 @@ export class SharedContent implements IClassSharedContent {
     );
     urlBuild.addParam("externalpath", arg.externalPath);
 
-    const status = await this.repoClient
+    const status = await this.#repoClient
       .Delete(urlBuild.getUrl())
       .then((res) => res.status);
 

--- a/src/SharedContents.ts
+++ b/src/SharedContents.ts
@@ -73,26 +73,26 @@ export interface IClassSharedContents {
 }
 
 export class SharedContents implements IClassSharedContents {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id)
       throw new Error(`sharedContent.get: "id" parameter is required`);
-    const shc: SharedContent = new SharedContent(this.repoClient, arg.id);
+    const shc: SharedContent = new SharedContent(this.#repoClient, arg.id);
     await shc.init();
 
     return shc;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`sharedcontent/full`)
       .then((res) => res.data as ISharedContent[])
       .then((data) => {
-        return data.map((t) => new SharedContent(this.repoClient, t.id, t));
+        return data.map((t) => new SharedContent(this.#repoClient, t.id, t));
       });
   }
 
@@ -102,11 +102,11 @@ export class SharedContents implements IClassSharedContents {
         `sharedContent.getFilter: "filter" parameter is required`
       );
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`sharedcontent/full?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as ISharedContent[])
       .then((data) => {
-        return data.map((t) => new SharedContent(this.repoClient, t.id, t));
+        return data.map((t) => new SharedContent(this.#repoClient, t.id, t));
       });
   }
 
@@ -128,7 +128,7 @@ export class SharedContents implements IClassSharedContents {
     const urlBuild = new URLBuild(`selection/sharedcontent`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }
@@ -147,16 +147,16 @@ export class SharedContents implements IClassSharedContents {
     if (arg.description) sharedContent["description"] = arg.description;
 
     const getCommon = new GetCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       arg.customProperties || [],
       arg.tags || [],
       ""
     );
     const commonProps = await getCommon.getAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`sharedcontent`, { ...sharedContent, ...commonProps })
       .then((res) => res.data as ISharedContent)
-      .then((s) => new SharedContent(this.repoClient, s.id, s));
+      .then((s) => new SharedContent(this.#repoClient, s.id, s));
   }
 }

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -10,28 +10,28 @@ export interface IClassStream {
 }
 
 export class Stream implements IClassStream {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: IStream;
   constructor(repoClient: QlikRepositoryClient, id: string, details?: IStream) {
     if (!id) throw new Error(`stream.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`stream/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`stream/${this.#id}`)
         .then((res) => res.data as IStream);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`stream/${this.id}`)
+    return await this.#repoClient
+      .Delete(`stream/${this.#id}`)
       .then((res) => res.status);
   }
 
@@ -39,14 +39,14 @@ export class Stream implements IClassStream {
     if (arg.name) this.details.name = arg.name;
 
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`stream/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IStream);
   }

--- a/src/Streams.ts
+++ b/src/Streams.ts
@@ -49,25 +49,25 @@ export interface IClassStreams {
 }
 
 export class Streams implements IClassStreams {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id) throw new Error(`steam.get: "id" parameter is required`);
-    const stream: Stream = new Stream(this.repoClient, arg.id);
+    const stream: Stream = new Stream(this.#repoClient, arg.id);
     await stream.init();
 
     return stream;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`stream/full`)
       .then((res) => res.data as IStream[])
       .then((data) => {
-        return data.map((t) => new Stream(this.repoClient, t.id, t));
+        return data.map((t) => new Stream(this.#repoClient, t.id, t));
       });
   }
 
@@ -75,11 +75,11 @@ export class Streams implements IClassStreams {
     if (!arg.filter)
       throw new Error(`stream.getFilter: "filter" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`stream/full?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as IStream[])
       .then((data) => {
-        return data.map((t) => new Stream(this.repoClient, t.id, t));
+        return data.map((t) => new Stream(this.#repoClient, t.id, t));
       });
   }
 
@@ -88,7 +88,7 @@ export class Streams implements IClassStreams {
       throw new Error(`stream.create: "path" parameter is required`);
 
     let getCommonProps = new GetCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       arg.customProperties,
       arg.tags,
       arg.owner
@@ -96,13 +96,13 @@ export class Streams implements IClassStreams {
 
     let commonProps = await getCommonProps.getAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`stream`, {
         name: arg.name,
         ...commonProps,
       })
       .then((res) => res.data as IStream)
-      .then((s) => new Stream(this.repoClient, s.id, s));
+      .then((s) => new Stream(this.#repoClient, s.id, s));
   }
 
   public async removeFilter(arg: { filter: string }) {
@@ -121,7 +121,7 @@ export class Streams implements IClassStreams {
     const urlBuild = new URLBuild(`selection/stream`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/SystemRule.ts
+++ b/src/SystemRule.ts
@@ -15,8 +15,8 @@ export interface IClassSystemRule {
 }
 
 export class SystemRule implements IClassSystemRule {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: ISystemRule;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -25,22 +25,22 @@ export class SystemRule implements IClassSystemRule {
   ) {
     if (!id) throw new Error(`systemRules.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`systemrule/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`systemrule/${this.#id}`)
         .then((res) => res.data as ISystemRule);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`systemrule/${this.id}`)
+    return await this.#repoClient
+      .Delete(`systemrule/${this.#id}`)
       .then((res) => res.status);
   }
 
@@ -55,14 +55,14 @@ export class SystemRule implements IClassSystemRule {
     if (arg.context) this.details.ruleContext = getRuleContext(arg.context);
 
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`systemrule/${this.details.id}`, { ...this.details })
       .then((res) => res.data as ISystemRule);
   }

--- a/src/Table.ts
+++ b/src/Table.ts
@@ -31,9 +31,9 @@ export interface IClassTable {
 }
 
 export class Table {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async create(arg: ITableCreate) {
@@ -49,7 +49,7 @@ export class Table {
     urlBuild.addParam("sortColumn", arg.sortColumn);
     urlBuild.addParam("orderAscending", arg.orderAscending);
 
-    return await this.repoClient.Post(`${urlBuild.getUrl()}`, {
+    return await this.#repoClient.Post(`${urlBuild.getUrl()}`, {
       type: arg.type,
       columns: arg.columns,
     });

--- a/src/Tag.ts
+++ b/src/Tag.ts
@@ -10,28 +10,28 @@ export interface IClassTag {
 }
 
 export class Tag implements IClassTag {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: ITag;
   constructor(repoClient: QlikRepositoryClient, id: string, details?: ITag) {
     if (!id) throw new Error(`tags.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`tag/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`tag/${this.#id}`)
         .then((res) => res.data as ITag);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`tag/${this.id}`)
+    return await this.#repoClient
+      .Delete(`tag/${this.#id}`)
       .then((res) => res.status);
   }
 
@@ -41,8 +41,8 @@ export class Tag implements IClassTag {
     this.details.name = arg.name;
     this.details.modifiedDate = modifiedDateTime();
 
-    return await this.repoClient
-      .Put(`tag/${this.id}`, {
+    return await this.#repoClient
+      .Put(`tag/${this.#id}`, {
         ...this.details,
       })
       .then((res) => res.data as ITag);

--- a/src/Tags.ts
+++ b/src/Tags.ts
@@ -26,26 +26,26 @@ export interface IClassTags {
 }
 
 export class Tags implements IClassTags {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
-    const tag: Tag = new Tag(this.repoClient, arg.id);
+    const tag: Tag = new Tag(this.#repoClient, arg.id);
     await tag.init();
 
     return tag;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`tag/full`)
       .then((res) => {
         return res.data as ITag[];
       })
       .then((data) => {
-        return data.map((t) => new Tag(this.repoClient, t.id, t));
+        return data.map((t) => new Tag(this.#repoClient, t.id, t));
       });
   }
 
@@ -53,21 +53,21 @@ export class Tags implements IClassTags {
     if (!arg.filter)
       throw new Error(`tag.getFilter: "filter" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`tag?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as ITag[])
       .then((data) => {
-        return data.map((t) => new Tag(this.repoClient, t.id, t));
+        return data.map((t) => new Tag(this.#repoClient, t.id, t));
       });
   }
 
   public async create(arg: { name: string }) {
     if (!arg.name) throw new Error(`tag.create: "name" is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`tag`, { name: arg.name })
       .then((res) => res.data as ITag)
-      .then((t) => new Tag(this.repoClient, t.id, t));
+      .then((t) => new Tag(this.#repoClient, t.id, t));
   }
 
   public async createMany(arg: { names: string[] }) {
@@ -78,10 +78,10 @@ export class Tags implements IClassTags {
       return { name: n };
     });
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`tag/many`, data)
       .then((res) => res.data as ITag[])
-      .then((tags) => tags.map((t) => new Tag(this.repoClient, t.id, t)));
+      .then((tags) => tags.map((t) => new Tag(this.#repoClient, t.id, t)));
   }
 
   public async removeFilter(arg: { filter: string }) {
@@ -103,7 +103,7 @@ export class Tags implements IClassTags {
     const urlBuild = new URLBuild(`selection/tag`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -10,25 +10,25 @@ export interface IClassTask {
 }
 
 export class Task implements IClassTask {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: ITask;
   constructor(repoClient: QlikRepositoryClient, id: string, details?: ITask) {
     if (!id) throw new Error(`tasks.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`task/full?filter=(id eq ${this.id})`)
+      this.details = await this.#repoClient
+        .Get(`task/full?filter=(id eq ${this.#id})`)
         .then((res) => {
           if (res.data.length == 0)
             throw new Error(
-              `tasks.get: task with id "${this.id}" was not found`
+              `tasks.get: task with id "${this.#id}" was not found`
             );
 
           return res.data[0] as ITask;
@@ -37,18 +37,21 @@ export class Task implements IClassTask {
   }
 
   async start() {
-    return await this.repoClient
-      .Post(`task/${this.id}/start`, {})
+    return await this.#repoClient
+      .Post(`task/${this.#id}/start`, {})
       .then((res) => res.status);
   }
 
   async startSynchronous() {
-    return await this.repoClient.Post(`task/${this.id}/start/synchronous`, {});
+    return await this.#repoClient.Post(
+      `task/${this.#id}/start/synchronous`,
+      {}
+    );
   }
 
   async stop() {
-    return await this.repoClient
-      .Post(`task/${this.id}/stop`, {})
+    return await this.#repoClient
+      .Post(`task/${this.#id}/stop`, {})
       .then((res) => res.status);
   }
 }

--- a/src/TaskTriggers.ts
+++ b/src/TaskTriggers.ts
@@ -6,13 +6,13 @@ export interface IClassTaskTriggers {
 }
 
 export class TaskTriggers implements IClassTaskTriggers {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
-    const tag: Tag = new Tag(this.repoClient, arg.id);
+    const tag: Tag = new Tag(this.#repoClient, arg.id);
     await tag.init();
 
     return tag;

--- a/src/Tasks.ts
+++ b/src/Tasks.ts
@@ -9,26 +9,26 @@ export interface IClassTasks {
 }
 
 export class Tasks implements IClassTasks {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
-    const task: Task = new Task(this.repoClient, arg.id);
+    const task: Task = new Task(this.#repoClient, arg.id);
     await task.init();
 
     return task;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`task/full`)
       .then((res) => {
         return res.data as ITask[];
       })
       .then((data) => {
-        return data.map((t) => new Task(this.repoClient, t.id, t));
+        return data.map((t) => new Task(this.#repoClient, t.id, t));
       });
   }
 
@@ -36,11 +36,11 @@ export class Tasks implements IClassTasks {
     if (!arg.filter)
       throw new Error(`tasks.getFilter: "filter" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`tasks?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as ITask[])
       .then((data) => {
-        return data.map((t) => new Task(this.repoClient, t.id, t));
+        return data.map((t) => new Task(this.#repoClient, t.id, t));
       });
   }
 }

--- a/src/User.ts
+++ b/src/User.ts
@@ -14,28 +14,28 @@ export interface IClassUser {
 }
 
 export class User implements IClassUser {
-  private repoClient: QlikRepositoryClient;
-  public id: string;
+  #repoClient: QlikRepositoryClient;
+  #id: string;
   details: IUser;
   constructor(repoClient: QlikRepositoryClient, id: string, details?: IUser) {
     if (!id) throw new Error(`users.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`user/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`user/${this.#id}`)
         .then((res) => res.data as IUser);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`user/${this.id}`)
+    return await this.#repoClient
+      .Delete(`user/${this.#id}`)
       .then((res) => res.status);
   }
 
@@ -44,14 +44,14 @@ export class User implements IClassUser {
     if (arg.name) this.details.name = arg.name;
 
     let updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`user/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IUser);
   }

--- a/src/UserDirectories.ts
+++ b/src/UserDirectories.ts
@@ -125,13 +125,13 @@ export interface IClassUserDirectories {
 }
 
 export class UserDirectories implements IClassUserDirectories {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async count() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`userdirectory/count`)
       .then((res) => res.data as number);
   }
@@ -139,18 +139,18 @@ export class UserDirectories implements IClassUserDirectories {
   public async get(id: string) {
     if (!id) throw new Error(`userDirectories.get: "id" parameter is required`);
 
-    const ud: UserDirectory = new UserDirectory(this.repoClient, id);
+    const ud: UserDirectory = new UserDirectory(this.#repoClient, id);
     await ud.init();
 
     return ud;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`userdirectory/full`)
       .then((res) => res.data as IUserDirectory[])
       .then((data) => {
-        return data.map((t) => new UserDirectory(this.repoClient, t.id, t));
+        return data.map((t) => new UserDirectory(this.#repoClient, t.id, t));
       });
   }
 
@@ -160,11 +160,11 @@ export class UserDirectories implements IClassUserDirectories {
         `userDirectory.getFilter: "filter" parameter is required`
       );
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`userdirectory/full?filter=(${encodeURIComponent(filter)})`)
       .then((res) => res.data as IUserDirectory[])
       .then((data) => {
-        return data.map((t) => new UserDirectory(this.repoClient, t.id, t));
+        return data.map((t) => new UserDirectory(this.#repoClient, t.id, t));
       });
   }
 
@@ -186,7 +186,7 @@ export class UserDirectories implements IClassUserDirectories {
     const urlBuild = new URLBuild(`selection/userdirectory`);
     urlBuild.addParam("filter", filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }
@@ -195,7 +195,7 @@ export class UserDirectories implements IClassUserDirectories {
     if (!userDirectoryIds)
       throw new Error(`userDirectory.sync: "ids" parameter is required`);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`userdirectoryconnector/syncuserdirectories`, [...userDirectoryIds])
       .then((res) => res.status as IHttpStatus);
   }
@@ -214,7 +214,7 @@ export class UserDirectories implements IClassUserDirectories {
     obj.type = `Repository.UserDirectoryConnectors.${arg.type}`;
 
     const getCommonProps = new GetCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       [],
       arg.tags,
       ""
@@ -222,9 +222,9 @@ export class UserDirectories implements IClassUserDirectories {
 
     const commonProps = await getCommonProps.getAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`userdirectory`, { ...obj, ...commonProps })
       .then((res) => res.data as IUserDirectory)
-      .then((ud) => new UserDirectory(this.repoClient, ud.id, ud));
+      .then((ud) => new UserDirectory(this.#repoClient, ud.id, ud));
   }
 }

--- a/src/UserDirectory.ts
+++ b/src/UserDirectory.ts
@@ -19,8 +19,8 @@ export interface IClassUserDirectory {
 }
 
 export class UserDirectory implements IClassUserDirectory {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: IUserDirectory;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -29,35 +29,35 @@ export class UserDirectory implements IClassUserDirectory {
   ) {
     if (!id) throw new Error(`userDirectory.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`userdirectory/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`userdirectory/${this.#id}`)
         .then((res) => res.data as IUserDirectory);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`userdirectory/${this.id}`)
+    return await this.#repoClient
+      .Delete(`userdirectory/${this.#id}`)
       .then((res) => res.status);
   }
 
   public async removeAndUsers() {
-    return await this.repoClient
+    return await this.#repoClient
       .Delete(
-        `userdirectoryconnector/deleteudandusers?userDirectoryId=${this.id}`
+        `userdirectoryconnector/deleteudandusers?userDirectoryId=${this.#id}`
       )
       .then((res) => res.status);
   }
 
   public async sync() {
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`userdirectoryconnector/syncuserdirectories`, [this.details.id])
       .then((res) => res.status as IHttpStatus);
   }
@@ -76,14 +76,14 @@ export class UserDirectory implements IClassUserDirectory {
         arg.settings as unknown as IUserDirectorySettings[];
 
     const updateCommon = new UpdateCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       this.details,
       arg,
       options
     );
     this.details = await updateCommon.updateAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`userdirectory/${this.details.id}`, { ...this.details })
       .then((res) => res.data as IUserDirectory);
   }

--- a/src/Users.ts
+++ b/src/Users.ts
@@ -74,26 +74,26 @@ export interface IClassUsers {
 }
 
 export class Users implements IClassUsers {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
     if (!arg.id) throw new Error(`users.get: "id" parameter is required`);
-    const user: User = new User(this.repoClient, arg.id);
+    const user: User = new User(this.#repoClient, arg.id);
     await user.init();
 
     return user;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`user/full`)
       .then((res) => res.data as IUser[])
       .then((data) => {
         return data.map((t) => {
-          return new User(this.repoClient, t.id, t);
+          return new User(this.#repoClient, t.id, t);
         });
       });
   }
@@ -101,11 +101,11 @@ export class Users implements IClassUsers {
   public async getFilter(arg: { filter: string }) {
     if (!arg.filter)
       throw new Error(`user.getFilter: "filter" parameter is required`);
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`user/full?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as IUser[])
       .then((data) => {
-        return data.map((t) => new User(this.repoClient, t.id, t));
+        return data.map((t) => new User(this.#repoClient, t.id, t));
       });
   }
 
@@ -116,7 +116,7 @@ export class Users implements IClassUsers {
       throw new Error(`user.create: "userDirectory" parameter is required`);
 
     let getCommonProps = new GetCommonProperties(
-      this.repoClient,
+      this.#repoClient,
       arg.customProperties,
       arg.tags,
       ""
@@ -124,7 +124,7 @@ export class Users implements IClassUsers {
 
     let commonProps = await getCommonProps.getAll();
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`user`, {
         userId: arg.userId,
         userDirectory: arg.userDirectory,
@@ -133,7 +133,7 @@ export class Users implements IClassUsers {
         ...commonProps,
       })
       .then((res) => res.data as IUser)
-      .then((u) => new User(this.repoClient, u.id, u));
+      .then((u) => new User(this.#repoClient, u.id, u));
   }
 
   public async removeFilter(arg: { filter: string }) {
@@ -152,7 +152,7 @@ export class Users implements IClassUsers {
     const urlBuild = new URLBuild(`selection/user`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }

--- a/src/VirtualProxies.ts
+++ b/src/VirtualProxies.ts
@@ -30,26 +30,26 @@ export interface IClassVirtualProxies {
 }
 
 export class VirtualProxies implements IClassVirtualProxies {
-  private repoClient: QlikRepositoryClient;
+  #repoClient: QlikRepositoryClient;
   constructor(private mainRepoClient: QlikRepositoryClient) {
-    this.repoClient = mainRepoClient;
+    this.#repoClient = mainRepoClient;
   }
 
   public async get(arg: { id: string }) {
-    const vp: VirtualProxy = new VirtualProxy(this.repoClient, arg.id);
+    const vp: VirtualProxy = new VirtualProxy(this.#repoClient, arg.id);
     await vp.init();
 
     return vp;
   }
 
   public async getAll() {
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`virtualproxyconfig/full`)
       .then((res) => {
         return res.data as IVirtualProxyConfig[];
       })
       .then((data) => {
-        return data.map((t) => new VirtualProxy(this.repoClient, t.id, t));
+        return data.map((t) => new VirtualProxy(this.#repoClient, t.id, t));
       });
   }
 
@@ -59,11 +59,11 @@ export class VirtualProxies implements IClassVirtualProxies {
         `virtualProxies.getFilter: "filter" parameter is required`
       );
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`virtualproxyconfig?filter=(${encodeURIComponent(arg.filter)})`)
       .then((res) => res.data as IVirtualProxyConfig[])
       .then((data) => {
-        return data.map((t) => new VirtualProxy(this.repoClient, t.id, t));
+        return data.map((t) => new VirtualProxy(this.#repoClient, t.id, t));
       });
   }
 
@@ -90,7 +90,7 @@ export class VirtualProxies implements IClassVirtualProxies {
     const urlBuild = new URLBuild(`selection/virtualproxyconfig`);
     urlBuild.addParam("filter", arg.filter);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(urlBuild.getUrl(), {})
       .then((res) => res.data as ISelection);
   }
@@ -177,21 +177,21 @@ export class VirtualProxies implements IClassVirtualProxies {
     if (arg.oidcAttributeMap)
       data["oidcAttributeMap"] = parseOidcAttributeMap(arg.oidcAttributeMap);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Post(`virtualproxyconfig`, { ...data })
       .then((res) => res.data as IVirtualProxyConfig)
-      .then((d) => new VirtualProxy(this.repoClient, d.id, d));
+      .then((d) => new VirtualProxy(this.#repoClient, d.id, d));
   }
 
   private async parseLoadBalancingNodes(
     nodes: string[]
   ): Promise<IServerNodeConfigurationCondensed[]> {
-    let existingNodes = await this.repoClient
+    let existingNodes = await this.#repoClient
       .Get(`servernodeconfiguration/full`)
       .then((res) => res.data as IServerNodeConfiguration[])
       .then((data) => {
         return data.map((t) => {
-          return new Node(this.repoClient, t.id, t);
+          return new Node(this.#repoClient, t.id, t);
         });
       });
 

--- a/src/VirtualProxy.ts
+++ b/src/VirtualProxy.ts
@@ -22,8 +22,8 @@ export interface IClassVirtualProxy {
 }
 
 export class VirtualProxy implements IClassVirtualProxy {
-  private id: string;
-  private repoClient: QlikRepositoryClient;
+  #id: string;
+  #repoClient: QlikRepositoryClient;
   details: IVirtualProxyConfig;
   constructor(
     repoClient: QlikRepositoryClient,
@@ -32,22 +32,22 @@ export class VirtualProxy implements IClassVirtualProxy {
   ) {
     if (!id) throw new Error(`virtualProxy.get: "id" parameter is required`);
 
-    this.id = id;
-    this.repoClient = repoClient;
+    this.#id = id;
+    this.#repoClient = repoClient;
     if (details) this.details = details;
   }
 
   async init() {
     if (!this.details) {
-      this.details = await this.repoClient
-        .Get(`virtualproxyconfig/${this.id}`)
+      this.details = await this.#repoClient
+        .Get(`virtualproxyconfig/${this.#id}`)
         .then((res) => res.data as IVirtualProxyConfig);
     }
   }
 
   public async remove() {
-    return await this.repoClient
-      .Delete(`virtualproxyconfig/${this.id}`)
+    return await this.#repoClient
+      .Delete(`virtualproxyconfig/${this.#id}`)
       .then((res) => res.status);
   }
 
@@ -130,7 +130,7 @@ export class VirtualProxy implements IClassVirtualProxy {
         arg.oidcAttributeMap
       );
 
-    return await this.repoClient
+    return await this.#repoClient
       .Put(`virtualproxyconfig/${this.details.id}`, this.details)
       .then((res) => res.data as IVirtualProxyConfig);
   }
@@ -138,11 +138,11 @@ export class VirtualProxy implements IClassVirtualProxy {
   public async metadataExport(arg?: { fileName: string }) {
     if (!arg.fileName) arg.fileName = `${this.details.prefix}_metadata_sp.xml`;
 
-    let exportMetaData: string = await this.repoClient
+    let exportMetaData: string = await this.#repoClient
       .Get(`virtualproxyconfig/${this.details.id}/generate/samlmetadata`)
       .then((m) => m.data as string);
 
-    return await this.repoClient
+    return await this.#repoClient
       .Get(`download/samlmetadata/${exportMetaData}/${arg.fileName}`)
       .then((m) => m.data as Buffer);
   }
@@ -150,12 +150,12 @@ export class VirtualProxy implements IClassVirtualProxy {
   private async parseLoadBalancingNodes(
     nodes: string[]
   ): Promise<IServerNodeConfigurationCondensed[]> {
-    let existingNodes = await this.repoClient
+    let existingNodes = await this.#repoClient
       .Get(`servernodeconfiguration/full`)
       .then((res) => res.data as IServerNodeConfiguration[])
       .then((data) => {
         return data.map((t) => {
-          return new Node(this.repoClient, t.id, t);
+          return new Node(this.#repoClient, t.id, t);
         });
       });
 

--- a/test/phase1.spec.ts
+++ b/test/phase1.spec.ts
@@ -15,6 +15,7 @@ const helpers = new Helpers();
  */
 describe("Phase1", function () {
   this.timeout(30000);
+  this.slow(1000);
 
   /**
    * Get about
@@ -71,7 +72,7 @@ describe("Phase1", function () {
 
     let customProperty = await repoApi.customProperties.create({
       name: cpName,
-      choiceValues: [helpers.uuid(), helpers.uuid()],
+      choiceValues: cpValues,
       objectTypes: ["App", "Stream"],
     });
 
@@ -176,7 +177,7 @@ describe("Phase1", function () {
 
     const updatedExtension = await importExtension.update({
       customProperties: [
-        `${newCustomProperty.details.name}="${newCustomProperty.details.choiceValues[0]}`,
+        `${newCustomProperty.details.name}=${newCustomProperty.details.choiceValues[0]}`,
       ],
     });
 
@@ -303,7 +304,7 @@ describe("Phase1", function () {
       .then((t) => t.length);
 
     await newReloadTask2.triggersDetails[0].remove();
-    await newReloadTask2.triggersDetails[1].remove();
+    // await newReloadTask2.triggersDetails[1].remove();
     await newReloadTask1.remove();
     await newReloadTask2.remove();
     await uploadedApp.remove();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "./dist",
-        "target": "ES5",
+        "target": "ES2020",
         "declaration": true,
         "declarationDir": "./dist",
         "module": "ES6",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "./dist",
-        "target": "ES5",
+        "target": "ES2020",
         "declaration": true,
         "declarationDir": "./dist",
         "module": "CommonJS",


### PR DESCRIPTION
All methods are returning only data related to the object. `baseUrl`, `repoClient`, `id` and `genericClient` are no longer exposed. They dont need to be exposed anyway
closes #49